### PR TITLE
Fix output path in project files and build target

### DIFF
--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -79,7 +79,7 @@ describe('nx-dotnet project generator', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const absoluteDistPath = resolve(config.root, outputPath);
-    const expectedDistPath = resolve('./dist/test');
+    const expectedDistPath = resolve('./dist/libs/test');
 
     expect(absoluteDistPath).toEqual(expectedDistPath);
   });

--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -54,10 +54,22 @@ describe('nx-dotnet project generator', () => {
     expect(config).toBeDefined();
   });
 
+  it('should set output paths in build target', async () => {
+    await GenerateProject(appTree, options, dotnetClient, 'application');
+    const config = readProjectConfiguration(appTree, 'test');
+    const outputPath = config.targets.build.options.output;
+    expect(outputPath).toBeTruthy();
+
+    const absoluteDistPath = resolve(appTree.root, outputPath);
+    const expectedDistPath = resolve(appTree.root, './dist/apps/test');
+
+    expect(absoluteDistPath).toEqual(expectedDistPath);
+  });
+
   /**
    * This test requires a live dotnet client.
    */
-  it('should update output paths', async () => {
+  it('should update output paths in project file', async () => {
     await GenerateProject(
       appTree,
       {

--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -123,16 +123,16 @@ async function GenerateTestProject(
 
   if (!isDryRun() && !schema.skipOutputPathManipulation) {
     const testCsProj = await findProjectFileInPath(testRoot);
-    SetOutputPath(host, testProjectName, testCsProj);
+    SetOutputPath(host, testRoot, testCsProj);
     const baseCsProj = await findProjectFileInPath(schema.projectRoot);
-    SetOutputPath(host, schema.projectName, baseCsProj);
+    SetOutputPath(host, schema.projectRoot, baseCsProj);
     dotnetClient.addProjectReference(testCsProj, baseCsProj);
   }
 }
 
 function SetOutputPath(
   host: Tree,
-  projectName: string,
+  projectRootPath: string,
   projectFilePath: string
 ): void {
   const xml: XmlDocument = new XmlDocument(
@@ -142,7 +142,7 @@ function SetOutputPath(
   let outputPath = `${relative(
     dirname(projectFilePath),
     process.cwd()
-  )}/dist/${projectName}`;
+  )}/dist/${projectRootPath}`;
   outputPath = outputPath.replace('\\', '/'); // Forward slash works on windows, backslash does not work on mac/linux
 
   const textNode: Partial<XmlTextNode> = {
@@ -238,7 +238,7 @@ export async function GenerateProject(
   } else if (!options.skipOutputPathManipulation) {
     SetOutputPath(
       host,
-      normalizedOptions.projectName,
+      normalizedOptions.projectRoot,
       await findProjectFileInPath(normalizedOptions.projectRoot)
     );
   }

--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -92,7 +92,7 @@ async function GenerateTestProject(
     projectType: projectType,
     sourceRoot: `${testRoot}`,
     targets: {
-      build: GetBuildExecutorConfiguration(testName),
+      build: GetBuildExecutorConfiguration(testRoot),
       test: GetTestExecutorConfig(),
     },
     tags: schema.parsedTags,
@@ -187,7 +187,7 @@ export async function GenerateProject(
     projectType: projectType,
     sourceRoot: `${normalizedOptions.projectRoot}`,
     targets: {
-      build: GetBuildExecutorConfiguration(normalizedOptions.name),
+      build: GetBuildExecutorConfiguration(normalizedOptions.projectRoot),
       serve: GetServeExecutorConfig(),
     },
     tags: normalizedOptions.parsedTags,

--- a/packages/core/src/models/build-executor-configuration.ts
+++ b/packages/core/src/models/build-executor-configuration.ts
@@ -4,13 +4,13 @@ import { TargetConfiguration } from '@nrwl/devkit';
  * Returns a TargetConfiguration for the nx-dotnet/core:build executor
  */
 export function GetBuildExecutorConfiguration(
-  projectName: string
+  projectRoot: string
 ): BuildExecutorConfiguration {
-  const outputDirectory = `dist/${projectName}`;
+  const outputDirectory = `dist/${projectRoot}`;
 
   return {
     executor: '@nx-dotnet/core:build',
-    outputs: [outputDirectory],
+    outputs: ['{options.output}'],
     options: {
       output: outputDirectory,
       configuration: 'Debug',


### PR DESCRIPTION
Update all output paths to include the full path to the project root, similar to how the official Nx generators will format the output paths. Fixes #27 