### PR TITLE
fix(core): include serve target only for applications

### DIFF
--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -42,6 +42,12 @@ describe('nx-dotnet project generator', () => {
     expect(config).toBeDefined();
   });
 
+  it('should not include serve target for libraries', async () => {
+    await GenerateProject(appTree, options, dotnetClient, 'library');
+    const config = readProjectConfiguration(appTree, 'test');
+    expect(config.targets.serve).not.toBeDefined();
+  })
+
   it('should tag generated projects', async () => {
     await GenerateProject(appTree, options, dotnetClient, 'library');
     const config = readProjectConfiguration(appTree, 'test');
@@ -65,6 +71,12 @@ describe('nx-dotnet project generator', () => {
 
     expect(absoluteDistPath).toEqual(expectedDistPath);
   });
+
+  it('should include serve target for applications', async () => {
+    await GenerateProject(appTree, options, dotnetClient, 'application');
+    const config = readProjectConfiguration(appTree, 'test');
+    expect(config.targets.serve).toBeDefined();
+  })
 
   /**
    * This test requires a live dotnet client.

--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -188,7 +188,7 @@ export async function GenerateProject(
     sourceRoot: `${normalizedOptions.projectRoot}`,
     targets: {
       build: GetBuildExecutorConfiguration(normalizedOptions.projectRoot),
-      serve: GetServeExecutorConfig(),
+      ...(projectType === 'application' && { serve: GetServeExecutorConfig() }),
     },
     tags: normalizedOptions.parsedTags,
   };

--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -188,7 +188,7 @@ export async function GenerateProject(
     sourceRoot: `${normalizedOptions.projectRoot}`,
     targets: {
       build: GetBuildExecutorConfiguration(normalizedOptions.projectRoot),
-      ...(projectType === 'application' && { serve: GetServeExecutorConfig() }),
+      ...(projectType === 'application' ? { serve: GetServeExecutorConfig() } : {}),
     },
     tags: normalizedOptions.parsedTags,
   };


### PR DESCRIPTION
Do not include serve target for libraries as they cannot be run directly.

Fixes #28