### PR TITLE
fix(core): dep-graph with various directory separators

### DIFF
--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -63,7 +63,7 @@ function normalizeOptions(
 
   const npmScope = names(readWorkspaceConfiguration(host).npmScope).className;
   const featureScope = projectDirectory
-    .split('/')
+    .split(/(\/|\\)/gm)
     .map((part) => names(part).className);
   const namespaceName = [npmScope, ...featureScope].join('.');
 

--- a/packages/utils/src/lib/utility-functions/workspace.ts
+++ b/packages/utils/src/lib/utility-functions/workspace.ts
@@ -7,7 +7,7 @@ import {
 } from '@nrwl/devkit';
 
 import { readFileSync } from 'fs';
-import { isAbsolute, resolve } from 'path';
+import { isAbsolute, resolve, dirname } from 'path';
 import { XmlDocument, XmlElement } from 'xmldoc';
 
 import { NXDOTNET_TAG } from '../constants';
@@ -58,7 +58,7 @@ export function getDependantProjectsForNxProject(
         absoluteFilePath = includeFilePath;
       } else {
         absoluteFilePath = resolve(
-          netProjectFilePath.split('/').slice(0, -1).join('/'),
+          dirname(netProjectFilePath),
           includeFilePath,
         );
       }


### PR DESCRIPTION
MacOS / Linux use different directory separators, and we relied on it being a forward slash.


fixes #43