### PR TITLE
fix(core): add unused options parameter for restore

### DIFF
--- a/packages/core/src/generators/restore/generator.ts
+++ b/packages/core/src/generators/restore/generator.ts
@@ -7,6 +7,7 @@ import {
 
 export default async function (
   host: Tree,
+  _: null, // Nx will populate this with options, which are currently unused.
   dotnetClient = new DotNetClient(dotnetFactory()),
 ) {
   const projects = getNxDotnetProjects(host);


### PR DESCRIPTION
Add an unused parameter to keep Nx from overwriting the dotnet client.