### PR TITLE
Add lint support through the dotnet-format tool

### DIFF
--- a/packages/core/executors.json
+++ b/packages/core/executors.json
@@ -20,6 +20,11 @@
       "implementation": "./src/executors/publish/executor",
       "schema": "./src/executors/publish/schema.json",
       "description": "publish executor"
+    },
+    "format": {
+      "implementation": "./src/executors/format/executor",
+      "schema": "./src/executors/format/schema.json",
+      "description": "Formats and lints a project using the dotnet-format tool"
     }
   },
   "builders": {

--- a/packages/core/migrations.json
+++ b/packages/core/migrations.json
@@ -1,0 +1,10 @@
+{
+  "generators": {
+    "add-lint-target": {
+      "version": "0.7.0",
+      "description": "Adds lint target to all existing dotnet projects",
+      "cli": "nx",
+      "implementation": "./src/migrations/add-lint-target/add-lint-target"
+    }
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,5 +20,8 @@
   },
   "bugs": {
     "url": "https://github.com/nx-dotnet/nx-dotnet/issues/new?assignees=&labels=bug%2C+needs-triage&template=bug_report.md&title=%5BBUG%5D+"
+  },
+  "nx-migrate": {
+    "migrations": "./migrations.json"
   }
 }

--- a/packages/core/src/executors/format/executor.spec.ts
+++ b/packages/core/src/executors/format/executor.spec.ts
@@ -86,7 +86,7 @@ describe('Format Executor', () => {
     }
   });
 
-  it('calls build when 1 project file is found', async () => {
+  it('calls format when 1 project file is found', async () => {
     try {
       const directoryPath = `${root}/apps/my-app`;
       await fs.mkdir(directoryPath, { recursive: true });

--- a/packages/core/src/executors/format/executor.spec.ts
+++ b/packages/core/src/executors/format/executor.spec.ts
@@ -1,0 +1,104 @@
+import { ExecutorContext } from '@nrwl/devkit';
+
+import { promises as fs } from 'fs';
+
+import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
+import { rimraf } from '@nx-dotnet/utils';
+
+import executor from './executor';
+import { FormatExecutorSchema } from './schema';
+
+const options: FormatExecutorSchema = {
+  check: true,
+  verbosity: 'minimal',
+};
+
+const root = process.cwd() + '/tmp';
+
+jest.mock('../../../../dotnet/src/lib/core/dotnet.client');
+
+describe('Format Executor', () => {
+  let context: ExecutorContext;
+  let dotnetClient: DotNetClient;
+
+  beforeEach(() => {
+    context = {
+      root: root,
+      cwd: root,
+      projectName: 'my-app',
+      targetName: 'lint',
+      workspace: {
+        version: 2,
+        projects: {
+          'my-app': {
+            root: `${root}/apps/my-app`,
+            sourceRoot: `${root}/apps/my-app`,
+            targets: {
+              lint: {
+                executor: '@nx-dotnet/core:format',
+              },
+            },
+          },
+        },
+      },
+      isVerbose: false,
+    };
+    dotnetClient = new DotNetClient(mockDotnetFactory());
+  });
+
+  afterEach(async () => {
+    await rimraf(root);
+  });
+
+  it('detects no dotnet project', async () => {
+    expect.assertions(1);
+    try {
+      await executor(options, context, dotnetClient);
+    } catch (e) {
+      console.log(e.message);
+      expect(e.message).toMatch(
+        "Unable to find a build-able project within project's source directory!",
+      );
+    }
+  });
+
+  it('detects multiple dotnet projects', async () => {
+    expect.assertions(1);
+
+    try {
+      const directoryPath = `${root}/apps/my-app`;
+      await fs.mkdir(directoryPath, { recursive: true });
+      await Promise.all([
+        fs.writeFile(`${directoryPath}/1.csproj`, ''),
+        fs.writeFile(`${directoryPath}/2.csproj`, ''),
+      ]);
+    } catch (e) {
+      console.warn(e.message);
+    }
+
+    try {
+      await executor(options, context, dotnetClient);
+    } catch (e) {
+      console.log(e.message);
+      expect(e.message).toMatch(
+        "More than one build-able projects are contained within the project's source directory!",
+      );
+    }
+  });
+
+  it('calls build when 1 project file is found', async () => {
+    try {
+      const directoryPath = `${root}/apps/my-app`;
+      await fs.mkdir(directoryPath, { recursive: true });
+      await Promise.all([fs.writeFile(`${directoryPath}/1.csproj`, '')]);
+    } catch (e) {
+      console.warn(e.message);
+    }
+
+    const res = await executor(options, context, dotnetClient);
+    expect(
+      (dotnetClient as jest.Mocked<DotNetClient>).format,
+    ).toHaveBeenCalled();
+    expect(res.success).toBeTruthy();
+  });
+});

--- a/packages/core/src/executors/format/executor.ts
+++ b/packages/core/src/executors/format/executor.ts
@@ -1,0 +1,52 @@
+import { ExecutorContext } from '@nrwl/devkit';
+import {
+  DotNetClient,
+  dotnetFactory,
+  dotnetFormatFlags,
+} from '@nx-dotnet/dotnet';
+import {
+  getExecutedProjectConfiguration,
+  getProjectFileForNxProject,
+} from '@nx-dotnet/utils';
+import { FormatExecutorSchema } from './schema';
+
+function normalizeOptions(
+  options: FormatExecutorSchema,
+): Record<string, string | boolean | undefined> {
+  const { diagnostics, include, exclude, check, fix, ...flags } = options;
+  return {
+    ...flags,
+    diagnostics: Array.isArray(diagnostics)
+      ? diagnostics.join(' ')
+      : diagnostics,
+    include: Array.isArray(include) ? include.join(' ') : include,
+    exclude: Array.isArray(exclude) ? exclude.join(' ') : exclude,
+    check: fix ? false : check,
+  };
+}
+
+export default async function runExecutor(
+  options: FormatExecutorSchema,
+  context: ExecutorContext,
+  dotnetClient: DotNetClient = new DotNetClient(dotnetFactory()),
+) {
+  const nxProjectConfiguration = getExecutedProjectConfiguration(context);
+  const projectFilePath = await getProjectFileForNxProject(
+    nxProjectConfiguration,
+  );
+
+  const normalized = normalizeOptions(options);
+
+  dotnetClient.installTool('dotnet-format');
+  dotnetClient.format(
+    projectFilePath,
+    Object.keys(options).map((x) => ({
+      flag: x as dotnetFormatFlags,
+      value: normalized[x],
+    })),
+  );
+
+  return {
+    success: true,
+  };
+}

--- a/packages/core/src/executors/format/schema.d.ts
+++ b/packages/core/src/executors/format/schema.d.ts
@@ -1,0 +1,23 @@
+export interface FormatExecutorSchema {
+  noRestore?: boolean;
+  fixWhitespace?: boolean;
+  fixStyle?: string;
+  diagnostics?: string | string[];
+  include?: string[];
+  exclude?: string[];
+  check: boolean;
+  report?: string;
+  binarylog?: string;
+  verbosity:
+    | 'q'
+    | 'quiet'
+    | 'm'
+    | 'minimal'
+    | 'n'
+    | 'normal'
+    | 'd'
+    | 'detailed'
+    | 'diag'
+    | 'diagnostic';
+  fix?: boolean;
+}

--- a/packages/core/src/executors/format/schema.json
+++ b/packages/core/src/executors/format/schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "title": "Format executor",
+  "description": "Formats and lints a project using the dotnet-format tool",
+  "type": "object",
+  "properties": {
+    "noRestore": {
+      "type": "boolean",
+      "description": "Doesn't execute an implicit restore before formatting"
+    },
+    "fixWhitespace": {
+      "type": "boolean",
+      "alias": ["w"],
+      "description": "Run whitespace formatting. Run by default when not applying fixes."
+    },
+    "fixStyle": {
+      "type": "string",
+      "alias": ["s"],
+      "description": "Run code style analyzers and apply fixes."
+    },
+    "fixAnalyzers": {
+      "type": "string",
+      "alias": ["a"],
+      "description": "Run 3rd party analyzers and apply fixes."
+    },
+    "diagnostics": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "A space separated list of diagnostic ids to use as a filter when fixing code style or 3rd party analyzers."
+        },
+        {
+          "type": "array",
+          "description": "A list of diagnostic ids to use as a filter when fixing code style or 3rd party analyzers.",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "include": {
+      "type": "array",
+      "description": "A list of relative file or folder paths to include in formatting. All files are formatted if empty",
+      "items": {
+        "type": "string"
+      }
+    },
+    "exclude": {
+      "type": "array",
+      "description": "A list of relative file or folder paths to exclude from formatting.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "check": {
+      "type": "boolean",
+      "description": "Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.",
+      "default": true
+    },
+    "report": {
+      "type": "string",
+      "description": "Accepts a file path, which if provided, will produce a json report in the given directory."
+    },
+    "binarylog": {
+      "type": "string",
+      "description": "Log all project or solution load information to a binary log file."
+    },
+    "verbosity": {
+      "type": "string",
+      "description": "Set the verbosity level.",
+      "enum": [
+        "q",
+        "quiet",
+        "m",
+        "minimal",
+        "n",
+        "normal",
+        "d",
+        "detailed",
+        "diag",
+        "diagnostic"
+      ],
+      "default": "minimal"
+    },
+    "fix": {
+      "type": "boolean",
+      "description": "Formats files and saves changes to disk. Equivalent to setting --check=false."
+    }
+  },
+  "required": []
+}

--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -94,6 +94,19 @@ describe('nx-dotnet project generator', () => {
     expect(config.targets.serve).toBeDefined();
   });
 
+  it('should include lint target', async () => {
+    await GenerateProject(appTree, options, dotnetClient, 'application');
+    const config = readProjectConfiguration(appTree, 'test');
+    expect(config.targets.lint).toBeDefined();
+  });
+
+  it('should include lint target in test project', async () => {
+    options.testTemplate = 'nunit';
+    await GenerateProject(appTree, options, dotnetClient, 'application');
+    const config = readProjectConfiguration(appTree, 'test-test');
+    expect(config.targets.lint).toBeDefined();
+  });
+
   /**
    * This test requires a live dotnet client.
    */

--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -23,6 +23,7 @@ import {
 
 import {
   GetBuildExecutorConfiguration,
+  GetLintExecutorConfiguration,
   GetServeExecutorConfig,
   GetTestExecutorConfig,
   NxDotnetProjectGeneratorSchema,
@@ -97,6 +98,7 @@ async function GenerateTestProject(
     targets: {
       build: GetBuildExecutorConfiguration(testRoot),
       test: GetTestExecutorConfig(),
+      lint: GetLintExecutorConfiguration(),
     },
     tags: schema.parsedTags,
   });
@@ -192,6 +194,7 @@ export async function GenerateProject(
       ...(projectType === 'application'
         ? { serve: GetServeExecutorConfig() }
         : {}),
+      lint: GetLintExecutorConfiguration(),
     },
     tags: normalizedOptions.parsedTags,
   };

--- a/packages/core/src/migrations/add-lint-target/add-lint-target.ts
+++ b/packages/core/src/migrations/add-lint-target/add-lint-target.ts
@@ -1,0 +1,11 @@
+import { Tree, updateProjectConfiguration } from '@nrwl/devkit';
+import { getNxDotnetProjects } from '@nx-dotnet/utils';
+import { GetLintExecutorConfiguration } from '../../models';
+
+export default function update(host: Tree) {
+  const projects = getNxDotnetProjects(host);
+  for (const [name, project] of projects) {
+    project.targets.lint ??= GetLintExecutorConfiguration();
+    updateProjectConfiguration(host, name, project);
+  }
+}

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -2,3 +2,4 @@ export * from './build-executor-configuration';
 export * from './project-generator-schema';
 export * from './serve-executor-configuration';
 export * from './test-executor-configuration';
+export * from './lint-executor-configuration';

--- a/packages/core/src/models/lint-executor-configuration.ts
+++ b/packages/core/src/models/lint-executor-configuration.ts
@@ -1,0 +1,7 @@
+import { TargetConfiguration } from '@nrwl/devkit';
+
+export function GetLintExecutorConfiguration(): TargetConfiguration {
+  return {
+    executor: '@nx-dotnet/core:format',
+  };
+}

--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -10,11 +10,13 @@ import {
   buildKeyMap,
   dotnetAddPackageOptions,
   dotnetBuildOptions,
+  dotnetFormatOptions,
   dotnetNewOptions,
   dotnetPublishOptions,
   dotnetRunOptions,
   dotnetTemplate,
   dotnetTestOptions,
+  formatKeyMap,
   newKeyMap,
   publishKeyMap,
   testKeyMap,
@@ -127,6 +129,20 @@ export class DotNetClient {
 
   restoreTools(): Buffer {
     const cmd = `${this.cliCommand.command} tool restore`;
+    return this.logAndExecute(cmd);
+  }
+
+  format(project: string, parameters?: dotnetFormatOptions): Buffer {
+    let cmd = `${this.cliCommand.command} format ${project}`;
+    if (parameters) {
+      parameters = swapArrayFieldValueUsingMap(
+        parameters,
+        'flag',
+        formatKeyMap,
+      );
+      const paramString = parameters ? getParameterString(parameters) : '';
+      cmd = `${cmd} ${paramString}`;
+    }
     return this.logAndExecute(cmd);
   }
 

--- a/packages/dotnet/src/lib/models/dotnet-format/dotnet-format-flags.ts
+++ b/packages/dotnet/src/lib/models/dotnet-format/dotnet-format-flags.ts
@@ -1,0 +1,21 @@
+export type dotnetFormatFlags =
+  | 'noRestore'
+  // Deliberately excluding the folder option, as the csproj file is always used as the workspace.
+  | 'fixWhitespace'
+  | 'fixStyle'
+  | 'fixAnalyzers'
+  | 'diagnostics'
+  | 'include'
+  | 'exclude'
+  | 'check'
+  | 'report'
+  | 'binarylog'
+  | 'verbosity';
+// Deliberately excluding the version option, as it doesn't perform any actual formatting.
+
+export const formatKeyMap: Partial<{ [key in dotnetFormatFlags]: string }> = {
+  noRestore: 'no-restore',
+  fixWhitespace: 'fix-whitespace',
+  fixStyle: 'fix-style',
+  fixAnalyzers: 'fix-analyzers',
+};

--- a/packages/dotnet/src/lib/models/dotnet-format/dotnet-format-options.ts
+++ b/packages/dotnet/src/lib/models/dotnet-format/dotnet-format-options.ts
@@ -1,0 +1,6 @@
+import { dotnetFormatFlags } from './dotnet-format-flags';
+
+export type dotnetFormatOptions = {
+  flag: dotnetFormatFlags;
+  value?: string | boolean;
+}[];

--- a/packages/dotnet/src/lib/models/dotnet-format/index.ts
+++ b/packages/dotnet/src/lib/models/dotnet-format/index.ts
@@ -1,0 +1,2 @@
+export * from './dotnet-format-flags';
+export * from './dotnet-format-options';

--- a/packages/dotnet/src/lib/models/index.ts
+++ b/packages/dotnet/src/lib/models/index.ts
@@ -4,3 +4,4 @@ export * from './dotnet-run';
 export * from './dotnet-test';
 export * from './dotnet-add-package';
 export * from './dotnet-publish';
+export * from './dotnet-format';

--- a/workspace.json
+++ b/workspace.json
@@ -53,7 +53,12 @@
               },
               "LICENSE",
               "CHANGELOG.md",
-              "README.md"
+              "README.md",
+              {
+                "input": "./packages/core",
+                "glob": "migrations.json",
+                "output": "."
+              }
             ]
           }
         }


### PR DESCRIPTION
Add a new executor that runs the dotnet-format tool against the project, which defaults to checking only but can also automatically fix various issues. This executor is then added to all new and existing projects.

Fixes #13 