### PR TITLE
fix(utils): getDependantProjectsForNxProject should work on Unix

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "e2e-registry": "yarn verdaccio --config ./tools/scripts/local-registry/config.yml --listen 4872",
     "e2e-tests": "ts-node -P ./tools/scripts/tsconfig.e2e.json ./tools/scripts/e2e.ts",
     "e2e": "run-p -r e2e-registry \"e2e-tests {@}\" --",
-    "publish-local": "run-p \"rimraf tmp\" e2e-registry \"ts-node ./tools/scripts/publish-all 99.99.99 local\"",
+    "publish-local": "cp .npmrc.local .npmrc && run-p \"rimraf tmp\" e2e-registry \"ts-node ./tools/scripts/publish-all 99.99.99 local\"",
     "semantic-release": "semantic-release",
     "ts-node": "ts-node",
     "rimraf": "rimraf"

--- a/packages/utils/src/lib/utility-functions/workspace.ts
+++ b/packages/utils/src/lib/utility-functions/workspace.ts
@@ -45,6 +45,7 @@ export function getDependantProjectsForNxProject(
   const netProjectFilePath = getProjectFileForNxProjectSync(
     workspaceConfiguration.projects[targetProject],
   );
+  const hostProjectDirectory = dirname(netProjectFilePath).replace(/\\/g, '/');
 
   const xml: XmlDocument = new XmlDocument(
     readFileSync(netProjectFilePath).toString(),
@@ -52,15 +53,12 @@ export function getDependantProjectsForNxProject(
 
   xml.childrenNamed('ItemGroup').forEach((itemGroup) =>
     itemGroup.childrenNamed('ProjectReference').forEach((x: XmlElement) => {
-      const includeFilePath = x.attr['Include'];
+      const includeFilePath = x.attr['Include'].replace(/\\/g, '/');
       let absoluteFilePath: string;
       if (isAbsolute(includeFilePath)) {
         absoluteFilePath = includeFilePath;
       } else {
-        absoluteFilePath = resolve(
-          dirname(netProjectFilePath),
-          includeFilePath,
-        );
+        absoluteFilePath = resolve(hostProjectDirectory, includeFilePath);
       }
 
       Object.entries(projectRoots).forEach(([dependency, path]) => {


### PR DESCRIPTION
inconsistent directory separators between .net CLI caused path.resolve to behave weirdly.

fixes #43