### PR TITLE
Fix lint migration

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/nx-dotnet/nx-dotnet/issues/new?assignees=&labels=bug%2C+needs-triage&template=bug_report.md&title=%5BBUG%5D+"
   },
-  "nx-migrate": {
+  "nx-migrations": {
     "migrations": "./migrations.json"
   }
 }

--- a/packages/core/src/migrations/add-lint-target/add-lint-target.ts
+++ b/packages/core/src/migrations/add-lint-target/add-lint-target.ts
@@ -1,4 +1,4 @@
-import { Tree, updateProjectConfiguration } from '@nrwl/devkit';
+import { formatFiles, Tree, updateProjectConfiguration } from '@nrwl/devkit';
 import { getNxDotnetProjects } from '@nx-dotnet/utils';
 import { GetLintExecutorConfiguration } from '../../models';
 
@@ -8,4 +8,5 @@ export default function update(host: Tree) {
     project.targets.lint ??= GetLintExecutorConfiguration();
     updateProjectConfiguration(host, name, project);
   }
+  formatFiles(host);
 }


### PR DESCRIPTION
Update the package.json key to match what Nx is expecting and format the workspace.json file after it has been updated.