### PR TITLE
Remove extra separator from project names

### DIFF
--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -8,6 +8,7 @@ import { XmlDocument } from 'xmldoc';
 import {
   DotNetClient,
   dotnetFactory,
+  dotnetNewOptions,
   mockDotnetFactory,
 } from '@nx-dotnet/dotnet';
 import { findProjectFileInPath, NXDOTNET_TAG, rimraf } from '@nx-dotnet/utils';
@@ -105,6 +106,15 @@ describe('nx-dotnet project generator', () => {
     await GenerateProject(appTree, options, dotnetClient, 'application');
     const config = readProjectConfiguration(appTree, 'test-test');
     expect(config.targets.lint).toBeDefined();
+  });
+
+  it('should prepend directory name to project name', async () => {
+    options.directory = 'sub-dir';
+    const spy = spyOn(dotnetClient, 'new');
+    await GenerateProject(appTree, options, dotnetClient, 'library');
+    const dotnetOptions: dotnetNewOptions = spy.calls.mostRecent().args[1];
+    const nameFlag = dotnetOptions.find((flag) => flag.flag === 'name');
+    expect(nameFlag?.value).toBe('Proj.SubDir.Test');
   });
 
   /**

--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -19,14 +19,7 @@ import { GenerateProject } from './generate-project';
 describe('nx-dotnet project generator', () => {
   let appTree: Tree;
   let dotnetClient: DotNetClient;
-
-  const options: NxDotnetProjectGeneratorSchema = {
-    name: 'test',
-    language: 'C#',
-    template: 'classlib',
-    testTemplate: 'none',
-    skipOutputPathManipulation: true,
-  };
+  let options: NxDotnetProjectGeneratorSchema;
 
   beforeEach(() => {
     appTree = createTreeWithEmptyWorkspace();
@@ -34,6 +27,14 @@ describe('nx-dotnet project generator', () => {
 
     const packageJson = { scripts: {} };
     writeJson(appTree, 'package.json', packageJson);
+
+    options = {
+      name: 'test',
+      language: 'C#',
+      template: 'classlib',
+      testTemplate: 'none',
+      skipOutputPathManipulation: true,
+    };
   });
 
   afterEach(async () => {

--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -64,7 +64,7 @@ function normalizeOptions(
 
   const npmScope = names(readWorkspaceConfiguration(host).npmScope).className;
   const featureScope = projectDirectory
-    .split(/(\/|\\)/gm)
+    .split(/\/|\\/gm) // Without the unnecessary parentheses, the separator is excluded from the result array.
     .map((part) => names(part).className);
   const namespaceName = [npmScope, ...featureScope].join('.');
 


### PR DESCRIPTION
Remove the capturing parentheses from the split Regex to remove an extra dot from the name of the generated csproj file.

Fixes #60 