### PR TITLE
FIX: reference existing project file path

### DIFF
--- a/e2e/core-e2e/jest.config.js
+++ b/e2e/core-e2e/jest.config.js
@@ -11,5 +11,5 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/e2ecore-e2e',
-  testTimeout: 90000,
+  testTimeout: 120000,
 };

--- a/e2e/core-e2e/tests/nx-dotnet.spec.ts
+++ b/e2e/core-e2e/tests/nx-dotnet.spec.ts
@@ -3,6 +3,7 @@ import {
   checkFilesExist,
   ensureNxProject,
   readFile,
+  readJson,
   runNxCommandAsync,
   uniq,
 } from '@nrwl/nx-plugin/testing';
@@ -12,6 +13,8 @@ import { join } from 'path';
 import { XmlDocument } from 'xmldoc';
 
 import { findProjectFileInPathSync } from '@nx-dotnet/utils';
+
+const e2eDir = 'tmp/nx-e2e/proj';
 
 describe('nx-dotnet e2e', () => {
   it('should create apps, libs, and project references', async () => {
@@ -33,6 +36,42 @@ describe('nx-dotnet e2e', () => {
 
     expect(output.stdout).toMatch(/Reference .* added to the project/);
   });
+
+  it('should work with affected', async () => {
+    const testApp = uniq('app');
+    const testLib = uniq('lib');
+    ensureNxProject('@nx-dotnet/core', 'dist/packages/core');
+
+    await runNxCommandAsync(
+      `generate @nx-dotnet/core:app ${testApp} --language="C#" --template="webapi"`,
+    );
+
+    await runNxCommandAsync(
+      `generate @nx-dotnet/core:lib ${testLib} --language="C#" --template="classlib"`,
+    );
+
+    await runNxCommandAsync(
+      `generate @nx-dotnet/core:project-reference ${testApp} ${testLib}`,
+    );
+
+    const output = await runNxCommandAsync(
+      'print-affected --target build --base HEAD~1',
+    );
+
+    const depGraphCachePath = join(
+      __dirname,
+      '../../../',
+      e2eDir,
+      'node_modules/.cache/nx/nxdeps.json',
+    );
+
+    const deps = readJson(depGraphCachePath).nodes[testApp].data.files.find(
+      (x: { ext: string; deps: string[] }) => x.ext === '.csproj',
+    ).deps;
+
+    expect(output.stderr).toBeFalsy();
+    expect(deps).toContain(testLib);
+  }, 150000);
 
   describe('nx g app', () => {
     it('should obey dry-run', async () => {
@@ -73,7 +112,7 @@ describe('nx-dotnet e2e', () => {
         `generate @nx-dotnet/core:app ${app} --language="C#" --template="webapi"`,
       );
       const configFilePath = findProjectFileInPathSync(
-        join('tmp/nx-e2e/proj/apps', app),
+        join(e2eDir, 'apps', app),
       );
       const config = readFileSync(configFilePath).toString();
       const projectXml = new XmlDocument(config);

--- a/packages/core/src/graph/process-project-graph.ts
+++ b/packages/core/src/graph/process-project-graph.ts
@@ -5,7 +5,10 @@ import {
   ProjectGraphProcessorContext,
 } from '@nrwl/devkit';
 
-import { getDependantProjectsForNxProject } from '@nx-dotnet/utils';
+import {
+  getDependantProjectsForNxProject,
+  getProjectFileForNxProjectSync,
+} from '@nx-dotnet/utils';
 
 export function processProjectGraph(
   graph: ProjectGraph,
@@ -34,10 +37,11 @@ function visitProject(
   project: ProjectConfiguration,
   projectName: string,
 ) {
+  const projectFile = getProjectFileForNxProjectSync(project);
   getDependantProjectsForNxProject(
     projectName,
     context.workspace,
-    ({ projectFile }, dependencyName) => {
+    (config, dependencyName) => {
       builder.addExplicitDependency(projectName, projectFile, dependencyName);
     },
   );


### PR DESCRIPTION
Running "nx dep-graph" will currently generate the following error:
nx-dotnet encountered an error parsing dependencies for 'project name'