### PR TITLE
feat(core): added support for test project name suffix

### DIFF
--- a/e2e/core-e2e/tests/nx-dotnet.spec.ts
+++ b/e2e/core-e2e/tests/nx-dotnet.spec.ts
@@ -147,6 +147,26 @@ describe('nx-dotnet e2e', () => {
 
       expect(projectReference).toBeDefined();
     });
+
+    it('should create test project using suffix', async () => {
+      const app = uniq('app');
+      await runNxCommandAsync(
+        `generate @nx-dotnet/core:app ${app} --language="C#" --template="webapi" --test-template="none"`,
+      );
+      await runNxCommandAsync(
+        `generate @nx-dotnet/core:test ${app} --language="C#" --template="nunit" --suffix="integration-tests"`,
+      );
+
+      const config = readFile(
+        joinPathFragments(
+          'apps',
+          `${app}-integration-tests`,
+          `Proj.${names(app).className}.IntegrationTests.csproj`,
+        ),
+      );
+
+      expect(config).toBeDefined();
+    });
   });
 
   describe('nx g lib', () => {

--- a/packages/core/src/generators/test/generator.ts
+++ b/packages/core/src/generators/test/generator.ts
@@ -22,6 +22,7 @@ export default function (
 
   const projectGeneratorOptions: NxDotnetProjectGeneratorSchema = {
     ...options,
+    testProjectNameSuffix: options.suffix,
     name,
     language: options.language,
     skipOutputPathManipulation: options.skipOutputPathManipulation,

--- a/packages/core/src/generators/test/schema.json
+++ b/packages/core/src/generators/test/schema.json
@@ -40,6 +40,15 @@
         "items": ["C#", "F#", "VB"]
       }
     },
+    "suffix": {
+      "type": "string",
+      "description": "What suffix should be used for the tests project name?",
+      "default": "test",
+      "x-prompt": {
+        "message": "What suffix should be used for the tests project name?",
+        "type": "string"
+      }
+    },
     "skipOutputPathManipulation": {
       "type": "boolean",
       "description": "Skip XML changes for default build path",

--- a/packages/core/src/generators/utils/generate-test-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-test-project.spec.ts
@@ -1,6 +1,5 @@
 import {
   addProjectConfiguration,
-  readJson,
   readProjectConfiguration,
   Tree,
   writeJson,
@@ -101,11 +100,28 @@ describe('nx-dotnet test project generator', () => {
     expect(config.root).toBe('apps/domain/existing-app-test');
   });
 
+  xit('should determine directory from existing project and suffix', async () => {
+    options.testProjectNameSuffix = 'integration-tests';
+    testProjectName = options.name + '-' + options.testProjectNameSuffix;
+    await GenerateTestProject(appTree, options, dotnetClient);
+    const config = readProjectConfiguration(appTree, testProjectName);
+    expect(config.root).toBe('apps/domain/existing-app-integration-tests');
+  });
+
   xit('should prepend directory name to project name', async () => {
     const spy = jest.spyOn(dotnetClient, 'new');
     await GenerateTestProject(appTree, options, dotnetClient);
     const [, dotnetOptions] = spy.mock.calls[spy.mock.calls.length - 1];
     const nameFlag = dotnetOptions?.find((flag) => flag.flag === 'name');
     expect(nameFlag?.value).toBe('Proj.Domain.ExistingApp.Test');
+  });
+
+  xit('should prepend directory name with suffix to project name', async () => {
+    options.testProjectNameSuffix = 'integration-tests';
+    const spy = jest.spyOn(dotnetClient, 'new');
+    await GenerateTestProject(appTree, options, dotnetClient);
+    const [, dotnetOptions] = spy.mock.calls[spy.mock.calls.length - 1];
+    const nameFlag = dotnetOptions?.find((flag) => flag.flag === 'name');
+    expect(nameFlag?.value).toBe('Proj.Domain.ExistingApp.IntegrationTests');
   });
 });

--- a/packages/core/src/generators/utils/generate-test-project.ts
+++ b/packages/core/src/generators/utils/generate-test-project.ts
@@ -1,4 +1,4 @@
-import { addProjectConfiguration, Tree } from '@nrwl/devkit';
+import { addProjectConfiguration, names, Tree } from '@nrwl/devkit';
 
 import { DotNetClient, dotnetNewOptions } from '@nx-dotnet/dotnet';
 import { findProjectFileInPath, isDryRun } from '@nx-dotnet/utils';
@@ -25,8 +25,9 @@ export async function GenerateTestProject(
     schema = normalizeOptions(host, schema);
   }
 
-  const testRoot = schema.projectRoot + '-test';
-  const testProjectName = schema.projectName + '-test';
+  const suffix = schema.testProjectNameSuffix || 'test';
+  const testRoot = schema.projectRoot + '-' + suffix;
+  const testProjectName = schema.projectName + '-' + suffix;
 
   addProjectConfiguration(
     host,
@@ -52,11 +53,11 @@ export async function GenerateTestProject(
     },
     {
       flag: 'name',
-      value: schema.namespaceName + '.Test',
+      value: schema.namespaceName + '.' + names(suffix).className,
     },
     {
       flag: 'output',
-      value: schema.projectRoot + '-test',
+      value: schema.projectRoot + '-' + suffix,
     },
   ];
 

--- a/packages/core/src/models/project-generator-schema.ts
+++ b/packages/core/src/models/project-generator-schema.ts
@@ -10,6 +10,7 @@ export interface NxDotnetProjectGeneratorSchema {
   template: string;
   language: string;
   testTemplate: 'nunit' | 'mstest' | 'xunit' | 'none';
+  testProjectNameSuffix?: string;
   skipOutputPathManipulation: boolean;
   standalone: boolean;
   projectType?: ProjectType;

--- a/packages/core/src/models/test-generator-schema.ts
+++ b/packages/core/src/models/test-generator-schema.ts
@@ -2,6 +2,7 @@ export interface NxDotnetTestGeneratorSchema {
   name: string;
   testTemplate: 'xunit' | 'nunit' | 'mstest';
   language: string;
+  suffix?: string;
   skipOutputPathManipulation: boolean;
   standalone: boolean;
 }


### PR DESCRIPTION
As discussed in issue 77, this PR adds the ability to specify a suffix for test projects. Usage is as follows:

When creating a test project at the same time as an app, the following command creates a test project named `some-app-unit-tests` with the C# project/namespace named `<workspace>.SomeApp.UnitTests`:
```
nx generate @nx-dotnet/core:app --name=some-app --language=C# --template=console --testTemplate=xunit --testProjectNameSuffix=unit-tests
```

When creating a new test project for an existing app, the following command creates a test project named `some-app-integration-tests` with the C# project/namespace named `<workspace>.SomeApp.IntegrationTests`:
```
nx generate @nx-dotnet/core:test --name=some-app --language=C# --testTemplate=xunit --suffix=integration-tests
```

Note: tests have been added, but I notice some tests in `generate-test-project.spec.ts` were excluded as they fail due to apps being in sub-directories - not sure why. I've created similar tests for this new functionality, which also fail in the same way, and so they have also been excluded from the test run - I'll leave those with you to look at.