### PR TITLE
fix(core): display moduleBoundary JSON instead of [object Object]

### DIFF
--- a/packages/core/src/tasks/check-module-boundaries.ts
+++ b/packages/core/src/tasks/check-module-boundaries.ts
@@ -55,7 +55,9 @@ export async function checkModuleBoundariesForProject(
           )
         ) {
           violations.push(
-            `${project} cannot depend on ${name}. Project tag ${constraint} is not satisfied.`,
+            `${project} cannot depend on ${name}. Project tag ${JSON.stringify(
+              constraint,
+            )} is not satisfied.`,
           );
         }
       }


### PR DESCRIPTION
When module boundaries are violated, the text shown in the console is similar to the following:

```
alerts-api cannot depend on comments-domain. Project tag [object Object] is not satisfied.
```

This PR stringifies the module boundary JSON to give a little more insight:

```
alerts-api cannot depend on comments-domain. Project tag {"sourceTag":"scope:alerting","onlyDependOnLibsWithTags":["scope:alerting","scope:common"]} is not satisfied.```