### PR TITLE
fix(core): use fully qualified project name in msbuild task

### DIFF
--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -195,7 +195,7 @@ export function setOutputPath(
 
 export function addPrebuildMsbuildTask(
   host: Tree,
-  options: { projectRoot: string; name: string },
+  options: { projectRoot: string; projectName: string },
   xml: XmlDocument,
 ) {
   const scriptPath = normalizePath(
@@ -207,7 +207,7 @@ export function addPrebuildMsbuildTask(
 
   const fragment = new XmlDocument(`
     <Target Name="CheckNxModuleBoundaries" BeforeTargets="Build">
-      <Exec Command="node ${scriptPath} -p ${options.name}"/>
+      <Exec Command="node ${scriptPath} -p ${options.projectName}"/>
     </Target>
   `);
 

--- a/packages/core/src/migrations/1.2.0/add-module-boundaries-check/migrate.ts
+++ b/packages/core/src/migrations/1.2.0/add-module-boundaries-check/migrate.ts
@@ -23,7 +23,11 @@ export default async function update(host: Tree) {
         .childrenNamed('Target')
         .some((x) => x.attr['Name'] === 'CheckNxModuleBoundaries')
     ) {
-      addPrebuildMsbuildTask(host, { name, projectRoot: project.root }, xml);
+      addPrebuildMsbuildTask(
+        host,
+        { projectName: name, projectRoot: project.root },
+        xml,
+      );
       host.write(projectFilePath, xml.toString());
     }
   }


### PR DESCRIPTION
When creating new projects that reside in a directory, the project name that appears in the MSBuild target uses the short name specified in the `--name=` argument rather than the fully qualified nx project name. This causes the project to fail when building with the following error (as the short name cannot be found in the nx config):

```
  Checking module boundaries for example-project
  (node:19408) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'root' of undefined
      at /Users/tom.davis/Contingent/services-dotnet/node_modules/@nx-dotnet/core/src/tasks/check-module-boundaries.js:13:57
      at Generator.next (<anonymous>)
      at /Users/tom.davis/Contingent/services-dotnet/node_modules/tslib/tslib.js:117:75
      at new Promise (<anonymous>)
      at Object.__awaiter (/Users/tom.davis/Contingent/services-dotnet/node_modules/tslib/tslib.js:113:16)
      at checkModuleBoundariesForProject (/Users/tom.davis/Contingent/services-dotnet/node_modules/@nx-dotnet/core/src/tasks/check-module-boundaries.js:12:20)
      at /Users/tom.davis/Contingent/services-dotnet/node_modules/@nx-dotnet/core/src/tasks/check-module-boundaries.js:80:34
      at Generator.next (<anonymous>)
      at fulfilled (/Users/tom.davis/Contingent/services-dotnet/node_modules/tslib/tslib.js:114:62)
  (Use `node --trace-warnings ...` to show where the warning was created)
  ```

To recreate:

```
nx generate @nx-dotnet/core:lib --name=domain --language=C# --template=classlib --testTemplate=none --directory=alerting
```

The .csproj file will contain the following:

```
  <Target Name="CheckNxModuleBoundaries" BeforeTargets="Build">    
    <Exec Command="node ../../../node_modules/@nx-dotnet/core/src/tasks/check-module-boundaries.js -p domain123"/>    
  </Target>
```

...the argument `domain123` should be `alerting-domain123`.