### PR TITLE
fix(core): use test project name in msbuild task instead of project under test

### DIFF
--- a/packages/core/src/generators/utils/generate-test-project.ts
+++ b/packages/core/src/generators/utils/generate-test-project.ts
@@ -68,7 +68,11 @@ export async function GenerateTestProject(
   dotnetClient.new(schema.testTemplate, newParams);
 
   if (!isDryRun() && !schema.skipOutputPathManipulation) {
-    await manipulateXmlProjectFile(host, { ...schema, projectRoot: testRoot });
+    await manipulateXmlProjectFile(host, {
+      ...schema,
+      projectRoot: testRoot,
+      projectName: testProjectName,
+    });
     const testCsProj = await findProjectFileInPath(testRoot);
     const baseCsProj = await findProjectFileInPath(schema.projectRoot);
     dotnetClient.addProjectReference(testCsProj, baseCsProj);


### PR DESCRIPTION
When creating test projects, the argument passed to the check-module-boundaries.js script in the MSBuild task is the name of the project *under* test; I believe this argument should actually be the name of test project itself.

To recreate:

```
# 1. Create app

nx generate @nx-dotnet/core:app --name=example-app --language=C# --template=console --standalone --testTemplate=none


# example-app .csproj file shows that module boundaries will be checked for "example-app" - this appears to be correct:

<Target Name="CheckNxModuleBoundaries" BeforeTargets="Build">
  <Exec Command="node ../../node_modules/@nx-dotnet/core/src/tasks/check-module-boundaries.js -p example-app"/>
</Target>


# 2. Create test project

nx generate @nx-dotnet/core:test --name=example-app --language=C# --testTemplate=xunit --standalone --no-interactive


# example-app-test .csproj file shows that module boundaries will be checked for "example-app" instead of "example-app-test"

<Target Name="CheckNxModuleBoundaries" BeforeTargets="Build">
  <Exec Command="node ../../node_modules/@nx-dotnet/core/src/tasks/check-module-boundaries.js -p example-app" />
</Target>

```




