### PR TITLE
chore(repo): fix Husky hooks failing on Win10

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
+. "$(dirname "$0")/common.sh"
 
 yarn commitlint --edit "$1"

--- a/.husky/common.sh
+++ b/.husky/common.sh
@@ -1,0 +1,8 @@
+command_exists () {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Workaround for Windows 10, Git Bash and Yarn
+if command_exists winpty && test -t 1; then
+  exec < /dev/tty
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
+. "$(dirname "$0")/common.sh"
 
 yarn lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
+. "$(dirname "$0")/common.sh"
 
 yarn documentation:check


### PR DESCRIPTION
This commit fixes well know problem on Windows OS:
https://typicode.github.io/husky/#/?id=yarn-on-windows

```text
stdin is not a tty
husky - pre-push hook exited with code 1 (error)
```
Changes as per Husky docs.

```text
 git push
 yarn run v1.22.5
 $ ts-node ./tools/scripts/hooks/documentation.check.ts
 � Checking for documentation changes
 � Finding changed files with "git diff --name-only
 8f052c71d3eb6950dd15bd4b504abe0ebbad6de6 -- docs"
 � Finding new files with "git ls-files -z -o --exclude-standard --
 docs"
 Done in 9.38s.
 Everything up-to-date
 ```

 Thanks!