### PR TITLE
test: manual mocks for nx-dotnet/dotnet

### DIFF
--- a/packages/core/__mocks__/@nx-dotnet/dotnet/index.ts
+++ b/packages/core/__mocks__/@nx-dotnet/dotnet/index.ts
@@ -1,0 +1,25 @@
+/// <reference types="jest" />
+import { DotnetFactory } from '@nx-dotnet/dotnet';
+
+const dotnetFactory: DotnetFactory = () => ({
+  command: 'echo',
+  info: {
+    global: true,
+    version: 0,
+  },
+});
+
+const DotNetClient = jest.fn().mockImplementation(() => ({
+  cwd: '',
+  addPackageReference: jest.fn(),
+  build: jest.fn(),
+  format: jest.fn(),
+  installTool: jest.fn(),
+  new: jest.fn(),
+  printSdkVersion: jest.fn(),
+  publish: jest.fn(),
+  restoreTools: jest.fn(),
+  test: jest.fn(),
+}));
+
+export { dotnetFactory, DotNetClient };

--- a/packages/core/src/executors/build/executor.spec.ts
+++ b/packages/core/src/executors/build/executor.spec.ts
@@ -2,7 +2,7 @@ import { ExecutorContext } from '@nrwl/devkit';
 
 import { promises as fs } from 'fs';
 
-import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
+import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
 import { rimraf } from '@nx-dotnet/utils';
 import { assertErrorMessage } from '@nx-dotnet/utils/testing';
 
@@ -14,8 +14,6 @@ const options: BuildExecutorSchema = {
 };
 
 const root = process.cwd() + '/tmp';
-
-jest.mock('../../../../dotnet/src/lib/core/dotnet.client');
 
 describe('Build Executor', () => {
   let context: ExecutorContext;
@@ -43,7 +41,7 @@ describe('Build Executor', () => {
       },
       isVerbose: false,
     };
-    dotnetClient = new DotNetClient(mockDotnetFactory());
+    dotnetClient = new DotNetClient(dotnetFactory());
   });
 
   afterEach(async () => {

--- a/packages/core/src/executors/format/executor.spec.ts
+++ b/packages/core/src/executors/format/executor.spec.ts
@@ -2,7 +2,7 @@ import { ExecutorContext } from '@nrwl/devkit';
 
 import { promises as fs } from 'fs';
 
-import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
+import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
 import { rimraf } from '@nx-dotnet/utils';
 
 import executor from './executor';
@@ -15,8 +15,6 @@ const options: FormatExecutorSchema = {
 };
 
 const root = process.cwd() + '/tmp';
-
-jest.mock('../../../../dotnet/src/lib/core/dotnet.client');
 
 describe('Format Executor', () => {
   let context: ExecutorContext;
@@ -44,7 +42,7 @@ describe('Format Executor', () => {
       },
       isVerbose: false,
     };
-    dotnetClient = new DotNetClient(mockDotnetFactory());
+    dotnetClient = new DotNetClient(dotnetFactory());
   });
 
   afterEach(async () => {

--- a/packages/core/src/executors/publish/executor.spec.ts
+++ b/packages/core/src/executors/publish/executor.spec.ts
@@ -6,7 +6,7 @@ import {
 
 import { promises as fs } from 'fs';
 
-import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
+import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
 import { rimraf } from '@nx-dotnet/utils';
 
 import executor from './executor';
@@ -20,8 +20,6 @@ const options: PublishExecutorSchema = {
 };
 
 const root = process.cwd() + '/tmp';
-
-jest.mock('../../../../dotnet/src/lib/core/dotnet.client');
 
 describe('Publish Executor', () => {
   let context: ExecutorContext;
@@ -50,7 +48,7 @@ describe('Publish Executor', () => {
       isVerbose: false,
     };
     dotnetClient = new DotNetClient(
-      mockDotnetFactory(),
+      dotnetFactory(),
     ) as jest.Mocked<DotNetClient>;
   });
 

--- a/packages/core/src/executors/test/executor.spec.ts
+++ b/packages/core/src/executors/test/executor.spec.ts
@@ -2,7 +2,7 @@ import { ExecutorContext } from '@nrwl/devkit';
 
 import { mkdirSync, writeFileSync } from 'fs';
 
-import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
+import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
 import { rimraf } from '@nx-dotnet/utils';
 
 import executor from './executor';
@@ -10,8 +10,6 @@ import { TestExecutorSchema } from './schema';
 
 const options: TestExecutorSchema = {};
 const root = process.cwd() + '/tmp';
-
-jest.mock('../../../../dotnet/src/lib/core/dotnet.client');
 
 describe('Test Executor', () => {
   let context: ExecutorContext;
@@ -39,7 +37,7 @@ describe('Test Executor', () => {
       },
       isVerbose: false,
     };
-    dotnetClient = new DotNetClient(mockDotnetFactory());
+    dotnetClient = new DotNetClient(dotnetFactory());
   });
 
   afterEach(async () => {

--- a/packages/core/src/generators/app/generator.spec.ts
+++ b/packages/core/src/generators/app/generator.spec.ts
@@ -1,7 +1,7 @@
 import { Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
-import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
+import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
 
 import * as mockedProjectGenerator from '../utils/generate-project';
 import generator from './generator';
@@ -25,7 +25,7 @@ describe('nx-dotnet library generator', () => {
 
   beforeEach(() => {
     appTree = createTreeWithEmptyWorkspace();
-    dotnetClient = new DotNetClient(mockDotnetFactory());
+    dotnetClient = new DotNetClient(dotnetFactory());
   });
 
   it('should run successfully', async () => {

--- a/packages/core/src/generators/init/generator.spec.ts
+++ b/packages/core/src/generators/init/generator.spec.ts
@@ -1,7 +1,7 @@
 import { readJson, Tree, writeJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
-import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
+import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
 import { CONFIG_FILE_PATH, NxDotnetConfig } from '@nx-dotnet/utils';
 
 import generator from './generator';
@@ -12,7 +12,7 @@ describe('init generator', () => {
 
   beforeEach(() => {
     appTree = createTreeWithEmptyWorkspace();
-    dotnetClient = new DotNetClient(mockDotnetFactory());
+    dotnetClient = new DotNetClient(dotnetFactory());
 
     const packageJson = { scripts: {} };
     writeJson(appTree, 'package.json', packageJson);

--- a/packages/core/src/generators/lib/generator.spec.ts
+++ b/packages/core/src/generators/lib/generator.spec.ts
@@ -1,7 +1,7 @@
 import { Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
-import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
+import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
 
 import * as mockedProjectGenerator from '../utils/generate-project';
 import generator from './generator';
@@ -25,7 +25,7 @@ describe('nx-dotnet library generator', () => {
 
   beforeEach(() => {
     appTree = createTreeWithEmptyWorkspace();
-    dotnetClient = new DotNetClient(mockDotnetFactory());
+    dotnetClient = new DotNetClient(dotnetFactory());
   });
 
   it('should run successfully', async () => {

--- a/packages/core/src/generators/nuget-reference/generator.spec.ts
+++ b/packages/core/src/generators/nuget-reference/generator.spec.ts
@@ -3,7 +3,7 @@ import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
 import { prompt } from 'inquirer';
 
-import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
+import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
 import { updateConfig } from '@nx-dotnet/utils';
 
 import generator from './generator';
@@ -11,7 +11,6 @@ import { NugetReferenceGeneratorSchema } from './schema';
 
 import PromptUI = require('inquirer/lib/ui/prompt');
 
-jest.mock('../../../../dotnet/src/lib/core/dotnet.client');
 jest.mock('../../../../utils/src/lib/utility-functions/workspace');
 jest.mock('inquirer');
 
@@ -54,7 +53,7 @@ describe('nuget-reference generator', () => {
         return {};
       }) as () => Promise<unknown> & { ui: PromptUI });
 
-    dotnetClient = new DotNetClient(mockDotnetFactory());
+    dotnetClient = new DotNetClient(dotnetFactory());
   });
 
   it('runs calls dotnet add package reference', async () => {

--- a/packages/core/src/generators/restore/generator.spec.ts
+++ b/packages/core/src/generators/restore/generator.spec.ts
@@ -9,7 +9,6 @@ import generator from './generator';
 
 import PromptUI = require('inquirer/lib/ui/prompt');
 
-jest.mock('../../../../dotnet/src/lib/core/dotnet.client');
 jest.mock('../../../../utils/src/lib/utility-functions/workspace');
 jest.mock('inquirer');
 

--- a/packages/core/src/generators/sync/generator.spec.ts
+++ b/packages/core/src/generators/sync/generator.spec.ts
@@ -9,7 +9,6 @@ import generator from './generator';
 
 import PromptUI = require('inquirer/lib/ui/prompt');
 
-jest.mock('../../../../dotnet/src/lib/core/dotnet.client');
 jest.mock('../../../../utils/src/lib/utility-functions/workspace');
 jest.mock('inquirer');
 

--- a/packages/core/src/generators/test/generator.spec.ts
+++ b/packages/core/src/generators/test/generator.spec.ts
@@ -1,7 +1,7 @@
 import { addProjectConfiguration, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
-import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
+import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
 
 import * as mockedProjectGenerator from '../utils/generate-test-project';
 import generator from './generator';
@@ -28,7 +28,7 @@ describe('nx-dotnet test generator', () => {
       targets: {},
       projectType: 'application',
     });
-    dotnetClient = new DotNetClient(mockDotnetFactory());
+    dotnetClient = new DotNetClient(dotnetFactory());
   });
 
   it('should run successfully', async () => {

--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -3,14 +3,13 @@ import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
 import { resolve } from 'path';
 
-import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
+import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
 import { NXDOTNET_TAG } from '@nx-dotnet/utils';
 
 import { NxDotnetProjectGeneratorSchema } from '../../models';
 import { GenerateProject } from './generate-project';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'log').mockImplementation();
 
 describe('nx-dotnet project generator', () => {
   let appTree: Tree;
@@ -19,7 +18,7 @@ describe('nx-dotnet project generator', () => {
 
   beforeEach(() => {
     appTree = createTreeWithEmptyWorkspace();
-    dotnetClient = new DotNetClient(mockDotnetFactory());
+    dotnetClient = new DotNetClient(dotnetFactory());
 
     const packageJson = { scripts: {} };
     writeJson(appTree, 'package.json', packageJson);

--- a/packages/core/src/generators/utils/generate-test-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-test-project.spec.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 
 import { resolve } from 'path';
 
-import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
+import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
 import { NXDOTNET_TAG } from '@nx-dotnet/utils';
 
 import { GenerateTestProject } from './generate-test-project';
@@ -65,7 +65,7 @@ describe('nx-dotnet test project generator', () => {
         'apps/domain/existing-app/Proj.Domain.ExistingApp.csproj',
       );
 
-    dotnetClient = new DotNetClient(mockDotnetFactory());
+    dotnetClient = new DotNetClient(dotnetFactory());
 
     const packageJson = { scripts: {} };
     writeJson(appTree, 'package.json', packageJson);

--- a/packages/dotnet/src/lib/core/dotnet.factory.spec.ts
+++ b/packages/dotnet/src/lib/core/dotnet.factory.spec.ts
@@ -1,0 +1,69 @@
+import { execSync } from 'child_process';
+
+import { dotnetFactory } from './dotnet.factory';
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execSync: jest.fn(),
+}));
+const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+let dotnetVersion = '6.0.100-rc.1.21463.6';
+
+describe('dotnetFactory', () => {
+  beforeEach(() => {
+    mockExecSync.mockImplementation(() => dotnetVersion);
+  });
+
+  it('should be a function', () => {
+    expect(dotnetFactory).toBeInstanceOf(Function);
+  });
+
+  it('should call dotnet command internally', () => {
+    // act
+    dotnetFactory();
+
+    // assert
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(mockExecSync).toHaveBeenCalledWith('dotnet --version', {
+      encoding: 'utf8',
+    });
+  });
+
+  it.each(['6.0.100-rc.1.21463.6', '5.0.0.0-rc.1', '3.0.100-rc'])(
+    'should return cli information for %s dotnet version',
+    (expected) => {
+      // arrange
+      dotnetVersion = expected;
+
+      // act
+      const {
+        command,
+        info: { global, version },
+      } = dotnetFactory();
+
+      // assert
+      expect(command).toBe('dotnet');
+      expect(global).toBe(true);
+      expect(version).toBe(expected);
+    },
+  );
+
+  it('should throw custom error when dotnet tool is not installed', () => {
+    // arrange
+    mockExecSync.mockImplementation(() => {
+      throw new Error(
+        `'dotnet' is not recognized as an internal or external command`,
+      );
+    });
+
+    // act/assert
+    try {
+      dotnetFactory();
+      fail('should have thrown');
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'dotnet not installed. Local support not yet added https://github.com/AgentEnder/nx-dotnet/issues/3',
+      );
+    }
+  });
+});

--- a/packages/dotnet/src/lib/core/dotnet.factory.ts
+++ b/packages/dotnet/src/lib/core/dotnet.factory.ts
@@ -31,10 +31,6 @@ export function dotnetFactory(): LoadedCLI {
   }
 }
 
-export function mockDotnetFactory(): LoadedCLI {
-  return { command: 'echo', info: { global: true, version: 0 } };
-}
-
 export type LoadedCLI = {
   command: string;
   info: { global: boolean; version: string | number };

--- a/packages/dotnet/src/lib/core/dotnet.factory.ts
+++ b/packages/dotnet/src/lib/core/dotnet.factory.ts
@@ -16,7 +16,7 @@ export function dotnetFactory(): LoadedCLI {
   // return the command line for local or global dotnet
   // check if dotnet is installed
   try {
-    const version = execSync('dotnet --version').toString('utf-8').trim();
+    const version = execSync('dotnet --version', { encoding: 'utf8' }).trim();
     return {
       command: 'dotnet',
       info: {
@@ -36,4 +36,4 @@ export type LoadedCLI = {
   info: { global: boolean; version: string | number };
 };
 
-export type DotnetFactory = () => LoadedCLI;
+export type DotnetFactory = typeof dotnetFactory;


### PR DESCRIPTION
So this is more for discussion. I want to add new generators to the core package and I've noticed, you're impacted
(probably) by issue with Node definition files incorrectly supporting 'string' from `execAsync`, which was only fixed recently.
In short, it was not obvious in TS, how to get 'string' from the process instead of a buffer.
So I'd like to change this detail, first in `dotnetFactory` (which is a minor componnet) and later in `DotNetCient`.
To better support tests I'd like to remove 'mock' from a production code (different concerns) and mocks properly both factory and client. 
Here is an example of what can be changed, introducing this underlying change in factory method, covered by new tests.

The move would allow to ditch usage of `jest.mock('../../../../dotnet/src/lib/core/dotnet.client');`, which are not very well suited for entire nx workspace picture One could avoid those mports either by using manual mocks (like here) or with automatic mocks using proper Jest config entry to map path (like in tsconfig paths).

Please let me know your thoughs, thx!
