### PR TITLE
fix(core): process project graph shouldn't throw if not a .NET project

### DIFF
--- a/e2e/core-e2e/jest.config.js
+++ b/e2e/core-e2e/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   preset: '../../jest.preset.js',
   globals: {
     'ts-jest': {
-      tsConfig: '<rootDir>/tsconfig.spec.json',
+      tsconfig: '<rootDir>/tsconfig.spec.json',
     },
   },
   transform: {

--- a/e2e/core-e2e/tests/nx-dotnet.spec.ts
+++ b/e2e/core-e2e/tests/nx-dotnet.spec.ts
@@ -4,10 +4,10 @@ import {
   ensureNxProject,
   listFiles,
   readFile,
-  readJson,
   runCommand,
   runNxCommand,
   runNxCommandAsync,
+  runPackageManagerInstall,
   tmpProjPath,
   uniq,
   updateFile,
@@ -53,7 +53,19 @@ describe('nx-dotnet e2e', () => {
   it('should work with affected', async () => {
     const testApp = uniq('app');
     const testLib = uniq('lib');
+
     runCommand('git checkout -b "affected-tests"');
+    updateFile('package.json', (f) => {
+      const json = JSON.parse(f);
+      json.dependencies['@nrwl/angular'] = 'latest';
+      return JSON.stringify(json);
+    });
+    runPackageManagerInstall();
+
+    await runNxCommandAsync(
+      `generate @nrwl/angular:app ng-app --style css --routing false --no-interactive`,
+      // { cwd: e2eDir, stdio: 'inherit' },
+    );
 
     await runNxCommandAsync(
       `generate @nx-dotnet/core:app ${testApp} --language="C#" --template="webapi"`,
@@ -70,7 +82,7 @@ describe('nx-dotnet e2e', () => {
     const deps = await readDependenciesFromNxDepGraph(join(e2eDir), testApp);
     expect(deps).toContain(testLib);
     runCommand('git checkout main');
-  }, 150000);
+  }, 300000);
 
   describe('nx g app', () => {
     it('should obey dry-run', async () => {

--- a/packages/core/src/graph/process-project-graph.ts
+++ b/packages/core/src/graph/process-project-graph.ts
@@ -29,16 +29,30 @@ function visitProject(
   project: ProjectConfiguration,
   projectName: string,
 ) {
-  const projectFile = getProjectFileForNxProjectSync(project);
-  getDependantProjectsForNxProject(
-    projectName,
-    context.workspace,
-    (config, dependencyName, implicit) => {
-      if (implicit) {
-        builder.addImplicitDependency(projectName, dependencyName);
-      } else {
-        builder.addExplicitDependency(projectName, projectFile, dependencyName);
-      }
-    },
-  );
+  let projectFile: string | null = null;
+
+  try {
+    projectFile = getProjectFileForNxProjectSync(project);
+  } catch (e) {
+    if (process.env['NX_VERBOSE_LOGGING'] === 'true') {
+      console.log(e);
+    }
+  }
+  if (projectFile !== null) {
+    getDependantProjectsForNxProject(
+      projectName,
+      context.workspace,
+      (config, dependencyName, implicit) => {
+        if (implicit) {
+          builder.addImplicitDependency(projectName, dependencyName);
+        } else {
+          builder.addExplicitDependency(
+            projectName,
+            projectFile as string,
+            dependencyName,
+          );
+        }
+      },
+    );
+  }
 }

--- a/tools/scripts/e2e.ts
+++ b/tools/scripts/e2e.ts
@@ -49,7 +49,9 @@ async function runTest() {
       console.log('No tests to run');
     } else if (selectedProjects) {
       execSync(
-        `yarn nx run-many --target=e2e --projects=${selectedProjects} ${testNamePattern}`,
+        selectedProjects.split(',').length > 1
+          ? `yarn nx run-many --target=e2e --projects=${selectedProjects} ${testNamePattern}`
+          : `yarn nx run ${selectedProjects}:e2e ${testNamePattern}`,
         {
           stdio: [0, 1, 2],
           env: {


### PR DESCRIPTION
Closes #389 