### PR TITLE
fix(core): resolved package version not provided

### DIFF
--- a/packages/core/src/generators/nuget-reference/generator.spec.ts
+++ b/packages/core/src/generators/nuget-reference/generator.spec.ts
@@ -67,4 +67,25 @@ describe('nuget-reference generator', () => {
     await generator(appTree, options, dotnetClient);
     expect(prompt).toHaveBeenCalledTimes(1);
   });
+
+  it('provides resolved version to dotnet add package reference', async () => {
+    const { getProjectFileForNxProject } = await import('@nx-dotnet/utils');
+
+    const projectFilePath = 'libs/test/Test.csproj';
+
+    (getProjectFileForNxProject as jest.MockedFunction<() => Promise<string>>)
+      .mockReset()
+      .mockResolvedValue(projectFilePath);
+
+    updateConfig(appTree, {
+      nugetPackages: { [options.packageName]: '1.2.3' },
+    });
+    await generator(appTree, options, dotnetClient);
+    const mock = dotnetClient as jest.Mocked<DotNetClient>;
+    expect(mock.addPackageReference).toHaveBeenCalledWith(
+      projectFilePath,
+      options.packageName,
+      { allowVersionMismatch: false, version: '1.2.3' },
+    );
+  });
 });

--- a/packages/core/src/generators/nuget-reference/generator.ts
+++ b/packages/core/src/generators/nuget-reference/generator.ts
@@ -34,7 +34,7 @@ export default async function (
     resolvedVersion !== options.version &&
     resolvedVersion !== ALLOW_MISMATCH
   ) {
-    options.version = resolvedVersion;
+    params.version = resolvedVersion;
   }
 
   try {


### PR DESCRIPTION
Fixes an issue I came across while running the nuget reference generator.
Basically, the resolved version is not passed to addPackageReference on line 41. 