### PR TITLE
fix(core): test executor should fail properly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches: [master, dev]
 
-env:
-  NX_BRANCH: ${{ github.event.number }}
-  NX_RUN_GROUP: ${{ github.run_id }}
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,11 +1,6 @@
 name: Run PR checks
 
 on: pull_request
-    
-
-env:
-  NX_BRANCH: ${{ github.event.number }}
-  NX_RUN_GROUP: ${{ github.run_id }}
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,6 @@ name: Release
 
 on: workflow_dispatch
 
-env:
-  NX_BRANCH: ${{ github.event.number }}
-  NX_RUN_GROUP: ${{ github.run_id }}
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -5,11 +5,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
-  
-
-env:
-  NX_BRANCH: main
-  NX_RUN_GROUP: smoke
 
 jobs:
   smoke:

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -37,7 +37,7 @@ module.exports = {
       '@semantic-release/exec',
       {
         prepareCmd:
-          'npx ts-node tools/scripts/patch-package-versions ${nextRelease.version}',
+          'npx ts-node tools/scripts/patch-package-versions --version ${nextRelease.version} --project all',
         publishCmd: [
           'npx ts-node tools/scripts/publish-all ${nextRelease.version} ${nextRelease.channel}',
           'nx deploy docs-site',

--- a/e2e/core-e2e/tests/nx-dotnet.spec.ts
+++ b/e2e/core-e2e/tests/nx-dotnet.spec.ts
@@ -336,6 +336,7 @@ describe('nx-dotnet e2e', () => {
       expect(slnFile).toContain(app + '-test');
     });
   });
+
   describe('inferred targets', () => {
     let api: string;
     let projectFolder: string;
@@ -384,6 +385,37 @@ describe('nx-dotnet e2e', () => {
       writeFileSync(join(e2eDir, 'workspace.json'), workspaceJsonContents);
 
       writeFileSync(join(projectFolder, 'project.json'), projectJsonContents);
+    });
+  });
+
+  describe('@nx-dotnet/core:test', () => {
+    it('should test with xunit', () => {
+      const appProject = uniq('app');
+      const testProject = `${appProject}-test`;
+      runNxCommand(
+        `generate @nx-dotnet/core:app ${appProject} --language="C#" --template="webapi" --test-runner xunit`,
+      );
+
+      expect(() => runNxCommand(`test ${testProject}`)).not.toThrow();
+
+      updateFile(
+        `apps/${testProject}/UnitTest1.cs`,
+        `using Xunit;
+
+namespace Proj.${names(appProject).className}.Test;
+
+public class UnitTest1
+{
+    // This test should fail, as the e2e test is checking for test failures.
+    [Fact]
+    public void Test1()
+    {
+      Assert.Equal(1, 2)
+    }
+}`,
+      );
+
+      expect(() => runNxCommand(`test ${testProject}`)).toThrow();
     });
   });
 });

--- a/e2e/core-e2e/tests/nx-dotnet.spec.ts
+++ b/e2e/core-e2e/tests/nx-dotnet.spec.ts
@@ -60,7 +60,7 @@ describe('nx-dotnet e2e', () => {
     runCommand('git checkout -b "affected-tests"');
     updateFile('package.json', (f) => {
       const json = JSON.parse(f);
-      json.dependencies['@nrwl/angular'] = 'latest';
+      json.dependencies['@nrwl/angular'] = json.devDependencies['nx'];
       return JSON.stringify(json);
     });
     runPackageManagerInstall();
@@ -162,7 +162,11 @@ describe('nx-dotnet e2e', () => {
         `generate @nx-dotnet/core:app ${app} --language="C#" --template="webapi"`,
       );
       const promise = runNxCommandAsync(`lint ${app}`).then((x) => x.stderr);
-      await expect(promise).resolves.toContain('WHITESPACE');
+      await expect(promise).rejects.toThrow(
+        expect.objectContaining({
+          message: expect.stringContaining('WHITESPACE'),
+        }),
+      );
     });
   });
 

--- a/nx.json
+++ b/nx.json
@@ -40,6 +40,10 @@
       {
         "target": "prebuild",
         "projects": "self"
+      },
+      {
+        "target": "prebuild",
+        "projects": "dependencies"
       }
     ]
   },

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -21,7 +21,9 @@
     "prebuild": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": ["npx ts-node tools/scripts/patch-package-versions"]
+        "commands": [
+          "npx ts-node tools/scripts/patch-package-versions --project core"
+        ]
       }
     },
     "build": {

--- a/packages/core/src/executors/test/executor.ts
+++ b/packages/core/src/executors/test/executor.ts
@@ -1,4 +1,4 @@
-import { ExecutorContext } from '@nrwl/devkit';
+import { ExecutorContext, logger } from '@nrwl/devkit';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 
 import { resolve } from 'path';
@@ -29,18 +29,23 @@ export default async function runExecutor(
   dotnetClient.cwd = projectDirectory;
   const { watch, ...parsedOptions } = options;
 
-  const result = dotnetClient.test(
-    resolve(appRootPath, projectFilePath),
-    watch,
-    parsedOptions,
-  );
+  try {
+    const result = dotnetClient.test(
+      resolve(appRootPath, projectFilePath),
+      watch,
+      parsedOptions,
+    );
 
-  if (watch && isChildProcess(result)) {
-    await handleChildProcessPassthrough(result);
-    await rimraf(projectDirectory + '/bin');
-    await rimraf(projectDirectory + '/obj');
+    if (watch && isChildProcess(result)) {
+      await handleChildProcessPassthrough(result);
+      await rimraf(projectDirectory + '/bin');
+      await rimraf(projectDirectory + '/obj');
+    }
+    return {
+      success: true,
+    };
+  } catch (e) {
+    logger.error(e);
+    return { success: false };
   }
-  return {
-    success: true,
-  };
 }

--- a/packages/core/src/generators/app/schema.json
+++ b/packages/core/src/generators/app/schema.json
@@ -44,6 +44,7 @@
       "description": "Which template should be used for creating the tests project?",
       "default": "nunit",
       "enum": ["nunit", "xunit", "mstest", "none"],
+      "aliases": ["testRunner"],
       "x-prompt": {
         "message": "Which template should be used for creating the tests project",
         "type": "list",

--- a/packages/core/src/generators/lib/schema.json
+++ b/packages/core/src/generators/lib/schema.json
@@ -43,6 +43,7 @@
       "type": "string",
       "description": "Which template should be used for creating the tests project?",
       "default": "nunit",
+      "aliases": ["testRunner"],
       "x-prompt": {
         "message": "Which template should be used for creating the tests project",
         "type": "list",

--- a/packages/core/src/generators/test/schema.json
+++ b/packages/core/src/generators/test/schema.json
@@ -20,6 +20,7 @@
       "description": "Which template should be used for creating the tests project?",
       "default": "nunit",
       "enum": ["nunit", "xunit", "mstest"],
+      "aliases": ["testRunner"],
       "x-prompt": {
         "message": "Which template should be used for creating the tests project",
         "type": "list",

--- a/packages/dotnet/project.json
+++ b/packages/dotnet/project.json
@@ -21,7 +21,9 @@
     "prebuild": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": ["npx ts-node tools/scripts/patch-package-versions"]
+        "commands": [
+          "npx ts-node tools/scripts/patch-package-versions --project dotnet"
+        ]
       }
     },
     "build": {

--- a/packages/dotnet/src/lib/core/dotnet.client.spec.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.spec.ts
@@ -12,7 +12,9 @@ describe('dotnet client', () => {
       beforeEach(() => {
         spawnSyncSpy = jest
           .spyOn(cp, 'spawnSync')
-          .mockImplementation(jest.fn());
+          .mockReturnValue({ status: 0 } as Partial<
+            cp.SpawnSyncReturns<Buffer>
+          > as cp.SpawnSyncReturns<Buffer>);
       });
 
       afterEach(() => {

--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -166,13 +166,15 @@ export class DotNetClient {
   }
 
   private logAndExecute(params: string[]): void {
-    console.log(
-      `Executing Command: ${this.cliCommand.command} "${params.join('" "')}"`,
-    );
-    spawnSync(this.cliCommand.command, params, {
+    const cmd = `${this.cliCommand.command} "${params.join('" "')}"`;
+    console.log(`Executing Command: ${cmd}`);
+    const res = spawnSync(this.cliCommand.command, params, {
       cwd: this.cwd || process.cwd(),
       stdio: 'inherit',
     });
+    if (res.status !== 0) {
+      throw new Error(`dotnet execution returned status code ${res.status}`);
+    }
   }
 
   private execute(params: string[]): Buffer {

--- a/packages/nx-ghpages/project.json
+++ b/packages/nx-ghpages/project.json
@@ -21,7 +21,9 @@
     "prebuild": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": ["npx ts-node tools/scripts/patch-package-versions"]
+        "commands": [
+          "npx ts-node tools/scripts/patch-package-versions --project nx-ghpages"
+        ]
       }
     },
     "build": {

--- a/packages/nxdoc/project.json
+++ b/packages/nxdoc/project.json
@@ -21,7 +21,9 @@
     "prebuild": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": ["npx ts-node tools/scripts/patch-package-versions"]
+        "commands": [
+          "npx ts-node tools/scripts/patch-package-versions --project nxdoc"
+        ]
       }
     },
     "build": {

--- a/packages/typescript/project.json
+++ b/packages/typescript/project.json
@@ -21,7 +21,9 @@
     "prebuild": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": ["npx ts-node tools/scripts/patch-package-versions"]
+        "commands": [
+          "npx ts-node tools/scripts/patch-package-versions --project typescript"
+        ]
       }
     },
     "build": {

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -21,7 +21,9 @@
     "prebuild": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": ["npx ts-node tools/scripts/patch-package-versions"]
+        "commands": [
+          "npx ts-node tools/scripts/patch-package-versions --project utils"
+        ]
       }
     },
     "build": {

--- a/tools/scripts/patch-package-versions/index.ts
+++ b/tools/scripts/patch-package-versions/index.ts
@@ -4,6 +4,8 @@ import { Workspaces } from '@nrwl/tao/src/shared/workspace';
 import { execSync } from 'child_process';
 import { join } from 'path';
 
+import * as yargsParser from 'yargs-parser';
+
 import {
   existsSync,
   getWorkspacePackages,
@@ -14,6 +16,7 @@ import {
 
 export function PatchPackageVersions(
   newVersion: string,
+  pkg: string,
   updateGit = true,
   prebuild = false,
 ) {
@@ -32,7 +35,10 @@ export function PatchPackageVersions(
     });
   }
 
-  const projects = Object.values(workspace.projects);
+  const projects =
+    pkg === 'all'
+      ? Object.values(workspace.projects)
+      : [workspace.projects[pkg]];
 
   projects.forEach((projectConfiguration, idx) => {
     if (!projectConfiguration.targets?.build) {
@@ -89,5 +95,6 @@ function patchDependenciesSection(
 }
 
 if (require.main === module) {
-  PatchPackageVersions(process.argv[2], false, true);
+  const args = yargsParser(process.argv);
+  PatchPackageVersions(args.version, args.project, false, true);
 }

--- a/tools/scripts/publish-all/index.ts
+++ b/tools/scripts/publish-all/index.ts
@@ -14,7 +14,7 @@ export function publishAll(version: string, tag = 'latest') {
     stdio: 'inherit',
   });
 
-  PatchPackageVersions(version, false);
+  PatchPackageVersions(version, 'all', false);
 
   const projects = Object.values(workspace.projects);
   const environment = {

--- a/tools/utils/fs.ts
+++ b/tools/utils/fs.ts
@@ -2,6 +2,7 @@ import { Workspaces } from '@nrwl/tao/src/shared/workspace';
 
 import { readFileSync, statSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { format } from 'prettier';
 
 export function existsSync(path: string) {
   let results;
@@ -16,7 +17,10 @@ export function readJson(path: string) {
 }
 
 export function writeJson(path: string, object: any) {
-  return writeFileSync(path, JSON.stringify(object, null, 2));
+  const contents = format(JSON.stringify(object, null, 2), {
+    parser: 'json',
+  });
+  return writeFileSync(path, contents);
 }
 
 export function readWorkspaceJson() {


### PR DESCRIPTION
Moving from `execSync` -> `spawnSync` for logAndExecute resulted in some executors returning invalid results. Notably, `nx test` would return `{success: true}` despite the `dotnet test` command failing.
