### PR TITLE
fix(dotnet): expand env vars in cli parameters

### DIFF
--- a/packages/dotnet/src/lib/core/dotnet.client.spec.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.spec.ts
@@ -65,6 +65,17 @@ describe('dotnet client', () => {
         `);
         expect(spawnSyncSpy).toHaveBeenCalledTimes(1);
       });
+
+      it('should expand environment variables', () => {
+        process.env.FOO = 'bar';
+        dotnetClient.publish(
+          'my-project',
+          undefined,
+          undefined,
+          '-p:Name=$FOO',
+        );
+        expect(spawnSyncSpy.mock.calls[0][1]).toContain('-p:Name=bar');
+      });
     });
   });
 });

--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -166,8 +166,13 @@ export class DotNetClient {
   }
 
   private logAndExecute(params: string[]): void {
+    params = params.map((param) =>
+      param.replace(/\$(\w+)/, (match, varName) => process.env[varName] ?? ''),
+    );
+
     const cmd = `${this.cliCommand.command} "${params.join('" "')}"`;
     console.log(`Executing Command: ${cmd}`);
+
     const res = spawnSync(this.cliCommand.command, params, {
       cwd: this.cwd || process.cwd(),
       stdio: 'inherit',


### PR DESCRIPTION
Expand environment variables before passing args to the child process.