### PR TITLE
feat(core): update prompt for installed template to present available options

### DIFF
--- a/docs/core/generators/application.md
+++ b/docs/core/generators/application.md
@@ -18,7 +18,7 @@ Generate a dotnet project under the application directory.
 
 - (string): A directory where the project is placed
 
-### <span className="required">template</span>
+### template
 
 - (string): The template to instantiate when the command is invoked. Each template might have specific options you can pass.
 

--- a/docs/core/generators/library.md
+++ b/docs/core/generators/library.md
@@ -18,7 +18,7 @@ Generate a dotnet project under the library directory.
 
 - (string): A directory where the project is placed
 
-### <span className="required">template</span>
+### template
 
 - (string): The template to instantiate when the command is invoked. Each template might have specific options you can pass.
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/node": "17.0.18",
     "@types/react": "17",
     "@types/rimraf": "^3.0.2",
+    "@types/semver": "^7.3.9",
     "@types/tmp": "^0.2.3",
     "@types/yargs-parser": "^20.2.1",
     "@typescript-eslint/eslint-plugin": "5.12.1",

--- a/packages/core/src/generators/app/schema.json
+++ b/packages/core/src/generators/app/schema.json
@@ -27,8 +27,7 @@
     },
     "template": {
       "type": "string",
-      "description": "The template to instantiate when the command is invoked. Each template might have specific options you can pass.",
-      "x-prompt": "What template should the project be initialized with? (https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new#template-options)"
+      "description": "The template to instantiate when the command is invoked. Each template might have specific options you can pass."
     },
     "language": {
       "type": "string",
@@ -80,5 +79,5 @@
       "aliases": ["solution", "s"]
     }
   },
-  "required": ["name", "template", "language"]
+  "required": ["name", "language"]
 }

--- a/packages/core/src/generators/init/generator.ts
+++ b/packages/core/src/generators/init/generator.ts
@@ -8,7 +8,7 @@ import {
 } from '@nrwl/devkit';
 
 import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
-import { CONFIG_FILE_PATH, NxDotnetConfig } from '@nx-dotnet/utils';
+import { CONFIG_FILE_PATH, isDryRun, NxDotnetConfig } from '@nx-dotnet/utils';
 
 export async function initGenerator(
   host: Tree,
@@ -73,7 +73,7 @@ function updateNxJson(host: Tree) {
 
 function initToolManifest(host: Tree, dotnetClient: DotNetClient) {
   const initialized = host.exists('.config/dotnet-tools.json');
-  if (!initialized) {
+  if (!initialized && !isDryRun()) {
     console.log('Tool Manifest created for managing local .NET tools');
     dotnetClient.new('tool-manifest');
   }

--- a/packages/core/src/generators/lib/schema.json
+++ b/packages/core/src/generators/lib/schema.json
@@ -27,8 +27,7 @@
     },
     "template": {
       "type": "string",
-      "description": "The template to instantiate when the command is invoked. Each template might have specific options you can pass.",
-      "x-prompt": "What template should the project be initialized with? (https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new#template-options)"
+      "description": "The template to instantiate when the command is invoked. Each template might have specific options you can pass."
     },
     "language": {
       "type": "string",
@@ -74,5 +73,5 @@
       "aliases": ["solution", "s"]
     }
   },
-  "required": ["name", "template", "language", "testTemplate"]
+  "required": ["name", "language", "testTemplate"]
 }

--- a/packages/core/src/generators/test/generator.ts
+++ b/packages/core/src/generators/test/generator.ts
@@ -7,7 +7,7 @@ import { normalizeOptions } from '../utils/generate-project';
 import { GenerateTestProject } from '../utils/generate-test-project';
 import { NxDotnetGeneratorSchema } from './schema';
 
-export default function (
+export default async function (
   host: Tree,
   options: NxDotnetGeneratorSchema,
   dotnetClient = new DotNetClient(dotnetFactory()),
@@ -34,7 +34,10 @@ export default function (
     projectType: project.projectType ?? 'library',
   };
 
-  const normalizedOptions = normalizeOptions(host, projectGeneratorOptions);
+  const normalizedOptions = await normalizeOptions(
+    host,
+    projectGeneratorOptions,
+  );
 
   return GenerateTestProject(host, normalizedOptions, dotnetClient);
 }

--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -32,6 +32,15 @@ describe('nx-dotnet project generator', () => {
       standalone: false,
       projectType: 'application',
     };
+
+    jest.spyOn(dotnetClient, 'listInstalledTemplates').mockReturnValue([
+      {
+        shortNames: ['classlib'],
+        templateName: 'Class Library',
+        languages: ['C#'],
+        tags: [],
+      },
+    ]);
   });
 
   afterEach(async () => {

--- a/packages/core/src/generators/utils/generate-test-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-test-project.spec.ts
@@ -74,7 +74,6 @@ describe('nx-dotnet test project generator', () => {
 
     options = {
       name: 'domain-existing-app',
-      template: 'xunit',
       testTemplate: 'xunit',
       language: 'C#',
       skipOutputPathManipulation: true,

--- a/packages/core/src/generators/utils/generate-test-project.ts
+++ b/packages/core/src/generators/utils/generate-test-project.ts
@@ -22,7 +22,7 @@ export async function GenerateTestProject(
   dotnetClient: DotNetClient,
 ) {
   if (!('projectRoot' in schema)) {
-    schema = normalizeOptions(host, schema);
+    schema = await normalizeOptions(host, schema);
   }
 
   const suffix = schema.testProjectNameSuffix || 'test';

--- a/packages/core/src/generators/utils/prompt-for-template.ts
+++ b/packages/core/src/generators/utils/prompt-for-template.ts
@@ -9,10 +9,6 @@ export function promptForTemplate(
 ): string | Promise<string> {
   const available = client.listInstalledTemplates({ search, language });
 
-  if (available.length === 1) {
-    return available[0].shortNames[0];
-  }
-
   if (search) {
     const exactMatch = available.find((x) => x.shortNames.includes(search));
     if (exactMatch) {
@@ -27,7 +23,7 @@ export function promptForTemplate(
       message:
         'What template should the project be initialized with? (https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new#template-options) ',
       choices: available.map((a) => ({
-        value: a.shortNames,
+        value: a.shortNames[0],
         message: a.templateName,
       })),
     },

--- a/packages/core/src/generators/utils/prompt-for-template.ts
+++ b/packages/core/src/generators/utils/prompt-for-template.ts
@@ -1,0 +1,35 @@
+import { DotNetClient } from '@nx-dotnet/dotnet';
+
+import { prompt } from 'inquirer';
+
+export function promptForTemplate(
+  client: DotNetClient,
+  search?: string,
+  language?: string,
+): string | Promise<string> {
+  const available = client.listInstalledTemplates({ search, language });
+
+  if (available.length === 1) {
+    return available[0].shortNames[0];
+  }
+
+  if (search) {
+    const exactMatch = available.find((x) => x.shortNames.includes(search));
+    if (exactMatch) {
+      return exactMatch.shortNames[0];
+    }
+  }
+
+  return prompt<{ template: string }>([
+    {
+      name: 'template',
+      type: 'list',
+      message:
+        'What template should the project be initialized with? (https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new#template-options) ',
+      choices: available.map((a) => ({
+        value: a.shortNames,
+        message: a.templateName,
+      })),
+    },
+  ]).then((a) => a.template);
+}

--- a/packages/core/src/models/project-generator-schema.ts
+++ b/packages/core/src/models/project-generator-schema.ts
@@ -7,7 +7,7 @@ export interface NxDotnetProjectGeneratorSchema {
   name: string;
   tags?: string;
   directory?: string;
-  template: string;
+  template?: string;
   language: string;
   testTemplate: 'nunit' | 'mstest' | 'xunit' | 'none';
   testProjectNameSuffix?: string;

--- a/packages/dotnet/src/lib/core/dotnet.client.spec.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.spec.ts
@@ -80,25 +80,77 @@ describe('dotnet client', () => {
   });
 
   describe('listInstalledTemplates', () => {
-    it('should list default templates', () => {
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should list templates', () => {
+      jest.spyOn(cp, 'spawnSync').mockReturnValue({
+        status: 0,
+        stdout:
+          Buffer.from(`Templates                                         Short Name      Language      Tags               
+--------------------------------------------      ----------      --------      -------------------
+ASP.NET Core Empty                                web             [C#], F#      Web/Empty          
+ASP.NET Core Web App (Model-View-Controller)      mvc             [C#], F#      Web/MVC            
+ASP.NET Core Web App                              webapp          [C#]          Web/MVC/Razor Pages
+ASP.NET Core with Angular                         angular         [C#]          Web/MVC/SPA        
+ASP.NET Core with React.js                        react           [C#]          Web/MVC/SPA        
+ASP.NET Core with React.js and Redux              reactredux      [C#]          Web/MVC/SPA        
+ASP.NET Core Web API                              webapi          [C#], F#      Web/WebAPI         
+ASP.NET Core gRPC Service                         grpc            [C#]          Web/gRPC   `),
+      } as Partial<cp.SpawnSyncReturns<Buffer>> as cp.SpawnSyncReturns<Buffer>);
+
       const client = new DotNetClient(dotnetFactory());
       const results = client
         .listInstalledTemplates()
         .flatMap((x) => x.shortNames);
       expect(results).toContain('webapi');
-      expect(results).toContain('console');
+      expect(results).toContain('mvc');
       expect(results).toContain('webapp');
     });
 
     it('should filter by search', () => {
+      jest.spyOn(cp, 'spawnSync').mockReturnValue({
+        status: 0,
+        stdout: Buffer.from(`These templates matched your input: 'asp'.
+          
+Templates                                         Short Name      Language      Tags               
+--------------------------------------------      ----------      --------      -------------------
+ASP.NET Core Empty                                web             [C#], F#      Web/Empty          
+ASP.NET Core Web App (Model-View-Controller)      mvc             [C#], F#      Web/MVC            
+ASP.NET Core Web App                              webapp          [C#]          Web/MVC/Razor Pages
+ASP.NET Core with Angular                         angular         [C#]          Web/MVC/SPA        
+ASP.NET Core with React.js                        react           [C#]          Web/MVC/SPA        
+ASP.NET Core with React.js and Redux              reactredux      [C#]          Web/MVC/SPA        
+ASP.NET Core Web API                              webapi          [C#], F#      Web/WebAPI         
+ASP.NET Core gRPC Service                         grpc            [C#]          Web/gRPC   `),
+      } as Partial<cp.SpawnSyncReturns<Buffer>> as cp.SpawnSyncReturns<Buffer>);
+
       const client = new DotNetClient(dotnetFactory());
       const results = client.listInstalledTemplates({ search: 'asp' });
+      console.log(results);
       for (const result of results) {
         expect(result.templateName).toMatch(/^asp.*/i);
       }
     });
 
     it('should filter by language', () => {
+      jest.spyOn(cp, 'spawnSync').mockReturnValue({
+        status: 0,
+        stdout: Buffer.from(`These templates matched your input: language='C#'
+          
+Templates                                         Short Name      Language      Tags               
+--------------------------------------------      ----------      --------      -------------------
+ASP.NET Core Empty                                web             [C#], F#      Web/Empty          
+ASP.NET Core Web App (Model-View-Controller)      mvc             [C#], F#      Web/MVC            
+ASP.NET Core Web App                              webapp          [C#]          Web/MVC/Razor Pages
+ASP.NET Core with Angular                         angular         [C#]          Web/MVC/SPA        
+ASP.NET Core with React.js                        react           [C#]          Web/MVC/SPA        
+ASP.NET Core with React.js and Redux              reactredux      [C#]          Web/MVC/SPA        
+ASP.NET Core Web API                              webapi          [C#], F#      Web/WebAPI         
+ASP.NET Core gRPC Service                         grpc            [C#]          Web/gRPC   `),
+      } as Partial<cp.SpawnSyncReturns<Buffer>> as cp.SpawnSyncReturns<Buffer>);
+
       const client = new DotNetClient(dotnetFactory());
       const results = client.listInstalledTemplates({ language: 'C#' });
       for (const result of results) {

--- a/packages/dotnet/src/lib/core/dotnet.client.spec.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.spec.ts
@@ -1,5 +1,5 @@
 import { DotNetClient } from './dotnet.client';
-import { mockDotnetFactory } from './dotnet.factory';
+import { dotnetFactory, mockDotnetFactory } from './dotnet.factory';
 import * as cp from 'child_process';
 
 describe('dotnet client', () => {
@@ -76,6 +76,34 @@ describe('dotnet client', () => {
         );
         expect(spawnSyncSpy.mock.calls[0][1]).toContain('-p:Name=bar');
       });
+    });
+  });
+
+  describe('listInstalledTemplates', () => {
+    it('should list default templates', () => {
+      const client = new DotNetClient(dotnetFactory());
+      const results = client
+        .listInstalledTemplates()
+        .flatMap((x) => x.shortNames);
+      expect(results).toContain('webapi');
+      expect(results).toContain('console');
+      expect(results).toContain('webapp');
+    });
+
+    it('should filter by search', () => {
+      const client = new DotNetClient(dotnetFactory());
+      const results = client.listInstalledTemplates({ search: 'asp' });
+      for (const result of results) {
+        expect(result.templateName).toMatch(/^asp.*/i);
+      }
+    });
+
+    it('should filter by language', () => {
+      const client = new DotNetClient(dotnetFactory());
+      const results = client.listInstalledTemplates({ language: 'C#' });
+      for (const result of results) {
+        expect(result.languages).toContain('C#');
+      }
     });
   });
 });

--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -18,6 +18,7 @@ import {
   publishKeyMap,
   runKeyMap,
   testKeyMap,
+  DotnetTemplate,
 } from '../models';
 import { LoadedCLI } from './dotnet.factory';
 import { parseDotnetNewListOutput } from '../utils/parse-dotnet-new-list-output';
@@ -34,7 +35,10 @@ export class DotNetClient {
     return this.logAndExecute(params);
   }
 
-  listInstalledTemplates(opts?: { search?: string; language?: string }) {
+  listInstalledTemplates(opts?: {
+    search?: string;
+    language?: string;
+  }): DotnetTemplate[] {
     const version = this.getSdkVersion();
     const params: string[] = ['new'];
     if (semver.lt(version, '6.0.100') && opts?.search) {

--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -18,9 +18,9 @@ import {
   publishKeyMap,
   runKeyMap,
   testKeyMap,
-  DotnetTemplate,
 } from '../models';
 import { LoadedCLI } from './dotnet.factory';
+import { parseDotnetNewListOutput } from '../utils/parse-dotnet-new-list-output';
 
 export class DotNetClient {
   constructor(private cliCommand: LoadedCLI, public cwd?: string) {}
@@ -52,53 +52,7 @@ export class DotNetClient {
       params.push('--language', opts.language);
     }
     const output = this.spawnAndGetOutput(params);
-    return this.parseDotnetNewListOutput(output);
-  }
-
-  private parseDotnetNewListOutput(output: string) {
-    const lines = output.split('\n').filter((x) => !!x);
-    const sepLineIdx = lines.findIndex((line) => line.startsWith('----'));
-    if (!sepLineIdx) {
-      throw new Error('Unable to parse `dotnet new --list` output');
-    }
-    const sepLine = lines[sepLineIdx];
-    const columnIndicies: number[] = [];
-    let check = true;
-    for (let i = 0; i < sepLine.length; i++) {
-      if (sepLine[i] === '-' && check) {
-        columnIndicies.push(i);
-        check = false;
-      } else if (sepLine[i] !== '-') {
-        check = true;
-      }
-    }
-    const fieldLine = lines[sepLineIdx - 1];
-    const fields = columnIndicies.map((start, idx) => {
-      const end = columnIndicies[idx + 1] || fieldLine.length;
-      return {
-        start,
-        end,
-        name: fieldLine.substring(start, end).trim(),
-      };
-    });
-    return lines.slice(sepLineIdx + 1).map((l) =>
-      fields.reduce((obj, field) => {
-        const value = l.slice(field.start, field.end).trim();
-        if (field.name === 'Short Name') {
-          obj.shortNames = value.split(',');
-        } else if (
-          field.name === 'Template Name' ||
-          field.name === 'Templates'
-        ) {
-          obj.templateName = value;
-        } else if (field.name === 'Language') {
-          obj.languages = value.replace(/[\[\]]/g, '').split(',');
-        } else if (field.name === 'Tags') {
-          obj.tags = value.split('/');
-        }
-        return obj;
-      }, {} as DotnetTemplate),
-    );
+    return parseDotnetNewListOutput(output);
   }
 
   build(project: string, parameters?: dotnetBuildOptions): void {

--- a/packages/dotnet/src/lib/core/dotnet.factory.ts
+++ b/packages/dotnet/src/lib/core/dotnet.factory.ts
@@ -32,7 +32,7 @@ export function dotnetFactory(): LoadedCLI {
 }
 
 export function mockDotnetFactory(): LoadedCLI {
-  return { command: 'echo', info: { global: true, version: 0 } };
+  return { command: 'echo', info: { global: true, version: '6.0.100' } };
 }
 
 export type LoadedCLI = {

--- a/packages/dotnet/src/lib/models/dotnet-new/dotnet-template.ts
+++ b/packages/dotnet/src/lib/models/dotnet-new/dotnet-template.ts
@@ -1,4 +1,4 @@
-export type dotnetTemplate =
+export type KnownDotnetTemplates =
   | 'console'
   | 'classlib'
   | 'wpf'
@@ -27,3 +27,10 @@ export type dotnetTemplate =
   | 'webapi'
   | 'globaljson'
   | string;
+
+export interface DotnetTemplate {
+  templateName: string;
+  shortNames: string[];
+  languages?: string[];
+  tags?: string[];
+}

--- a/packages/dotnet/src/lib/models/dotnet-new/dotnet-template.ts
+++ b/packages/dotnet/src/lib/models/dotnet-new/dotnet-template.ts
@@ -30,7 +30,7 @@ export type KnownDotnetTemplates =
 
 export interface DotnetTemplate {
   templateName: string;
-  shortNames: string[];
+  shortNames: [string, ...string[]];
   languages?: string[];
   tags?: string[];
 }

--- a/packages/dotnet/src/lib/utils/parse-dotnet-new-list-output.ts
+++ b/packages/dotnet/src/lib/utils/parse-dotnet-new-list-output.ts
@@ -67,7 +67,7 @@ export function parseDotnetNewListOutput(rawOutput: string): DotnetTemplate[] {
       const value = l.slice(field.start, field.end).trim();
       // Map field name + value into expected form
       if (field.name === 'Short Name') {
-        obj.shortNames = value.split(',');
+        obj.shortNames = value.split(',') as [string, ...string[]];
       } else if (field.name === 'Template Name' || field.name === 'Templates') {
         obj.templateName = value;
       } else if (field.name === 'Language') {

--- a/packages/dotnet/src/lib/utils/parse-dotnet-new-list-output.ts
+++ b/packages/dotnet/src/lib/utils/parse-dotnet-new-list-output.ts
@@ -1,0 +1,81 @@
+import { DotnetTemplate } from '../models';
+
+/**
+ * Expected input is from running `dotnet new --list`.
+ * It should look something like below.
+ *
+ * Templates            Short Name       Languages
+ * ---------------      -----------      ------------
+ * ASP.NET Core         aspnetcore       C#
+ *
+ * We can parse this syntax based on the separator row. We
+ * know the separators are hyphens (-), with spaces between each column.
+ * Since the hyphens cover the length of the longest value, we can use the
+ * index of the first hyphen underneath each field to index the fields.
+ *
+ * For example, above the first hyphen under "Short Name" is in position 21,
+ * and the first hyphen under "Languages" is 39. This means that the values
+ * for "Short Name" must be found on each line between characters 21 and 39.
+ *
+ * So, for each line the value of shortName is line.substring(21, 39).trim()
+ *
+ * @param rawOutput The output from running `dotnet new --list`
+ * @retrurn Array of available templates found in raw output
+ */
+export function parseDotnetNewListOutput(rawOutput: string): DotnetTemplate[] {
+  const lines = rawOutput.split('\n').filter((x) => !!x);
+
+  // The separator row is used to index fields. It may be the first row, or
+  // if search values are provided it could be the third row.
+  const sepLineIdx = lines.findIndex((line) => line.startsWith('----'));
+  if (!sepLineIdx) {
+    throw new Error('Unable to parse `dotnet new --list` output');
+  }
+  const sepLine = lines[sepLineIdx];
+
+  // We know the separators are hyphens (-), with spaces between each column.
+  // We want to find the index of the first hyphen underneath each field.
+  const columnIndicies: number[] = [];
+  let check = true;
+  for (let i = 0; i < sepLine.length; i++) {
+    // First hyphen in a group
+    if (sepLine[i] === '-' && check) {
+      columnIndicies.push(i);
+      // Don't check until again until a non-hyphen character is found.
+      check = false;
+    } else if (sepLine[i] !== '-') {
+      check = true;
+    }
+  }
+
+  // Column headers are directly above the separator
+  const fieldLine = lines[sepLineIdx - 1];
+  const fields = columnIndicies.map((start, idx) => {
+    // Values end at the beginning of the next column, or the end of the line
+    const end = columnIndicies[idx + 1] || fieldLine.length;
+    return {
+      start,
+      end,
+      name: fieldLine.substring(start, end).trim(),
+    };
+  });
+
+  // For each line
+  return lines.slice(sepLineIdx + 1).map((l) =>
+    // Construct an object from its fields
+    fields.reduce((obj, field) => {
+      const value = l.slice(field.start, field.end).trim();
+      // Map field name + value into expected form
+      if (field.name === 'Short Name') {
+        obj.shortNames = value.split(',');
+      } else if (field.name === 'Template Name' || field.name === 'Templates') {
+        obj.templateName = value;
+      } else if (field.name === 'Language') {
+        obj.languages = value.replace(/[[\]]/g, '').split(',');
+      } else if (field.name === 'Tags') {
+        obj.tags = value.split('/');
+      }
+      return obj;
+    }, {} as DotnetTemplate),
+  );
+}

--- a/tools/scripts/sandbox.ts
+++ b/tools/scripts/sandbox.ts
@@ -15,7 +15,11 @@ const sandboxDirectory = join(__dirname, '../../tmp/sandbox');
 
 export function setup() {
   copySync('.npmrc.local', '.npmrc');
-  startCleanVerdaccioInstance();
+  try {
+    startCleanVerdaccioInstance();
+  } catch {
+    // Its ok.
+  }
   execSync('ts-node ./tools/scripts/publish-all 99.99.99 local', {
     env: {
       ...process.env,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3338,6 +3338,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/semver@^7.3.9":
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
+  integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
+
 "@types/serve-index@^1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.1.tgz#1b5e85370a192c01ec6cec4735cf2917337a6278"


### PR DESCRIPTION
Previously, we prompted with a link to MSDN and a free-text field. Now, we run `dotnet new --list` to generate the list of possible templates, filtering by the value provided by `--template {v}`. This results in a select instead of freetext, that is filtered by language and search term.