### PR TITLE
fix(core): remove workaround for broken dotnet format builtin

### DIFF
--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -169,7 +169,7 @@ export class DotNetClient {
     forceToolUsage?: boolean,
   ): void {
     const params = forceToolUsage
-      ? ['tool', 'run', 'dotnet-format', project]
+      ? ['tool', 'run', 'dotnet-format', '--', project]
       : [`format`, project];
     if (parameters) {
       parameters = swapKeysUsingMap(parameters, formatKeyMap);


### PR DESCRIPTION
## Current Behavior

Nx .NET always runs dotnet-format via the tool, since the included version of the tool is broken.

## Expected Behavior

Nx .NET takes advantage of the builtin since it is no longer broken.

## Related Issues

Fixes #435 