### PR TITLE
feat(core): adding templates with default output path properties to init generator

### DIFF
--- a/docs/core/generators/application.md
+++ b/docs/core/generators/application.md
@@ -30,10 +30,6 @@ Generate a dotnet project under the application directory.
 
 - (string): Which template should be used for creating the tests project?
 
-### skipOutputPathManipulation
-
-- (boolean): Skip XML changes for default build path
-
 ### standalone
 
 - (boolean): Should the project use project.json? If false, the project config is inside workspace.json

--- a/docs/core/generators/test.md
+++ b/docs/core/generators/test.md
@@ -22,10 +22,6 @@ Generate a .NET test project for an existing application or library
 
 - (string): What suffix should be used for the tests project name?
 
-### skipOutputPathManipulation
-
-- (boolean): Skip XML changes for default build path
-
 ### standalone
 
 - (boolean): Should the project use project.json? If false, the project config is inside workspace.json

--- a/packages/core/src/generators/app/generator.spec.ts
+++ b/packages/core/src/generators/app/generator.spec.ts
@@ -18,7 +18,6 @@ describe('nx-dotnet app generator', () => {
     language: 'C#',
     template: 'webapi',
     testTemplate: 'none',
-    skipOutputPathManipulation: false,
     projectType: 'application',
     standalone: false,
     skipSwaggerLib: true,

--- a/packages/core/src/generators/app/schema.json
+++ b/packages/core/src/generators/app/schema.json
@@ -55,11 +55,6 @@
         ]
       }
     },
-    "skipOutputPathManipulation": {
-      "type": "boolean",
-      "description": "Skip XML changes for default build path",
-      "default": false
-    },
     "standalone": {
       "type": "boolean",
       "description": "Should the project use project.json? If false, the project config is inside workspace.json"

--- a/packages/core/src/generators/import-projects/generator.ts
+++ b/packages/core/src/generators/import-projects/generator.ts
@@ -21,7 +21,6 @@ import {
   GetServeExecutorConfig,
   GetTestExecutorConfig,
 } from '../../models';
-import { manipulateXmlProjectFile } from '../utils/generate-project';
 
 export default async function (host: Tree) {
   const projectFiles = await getProjectFilesInWorkspace(host);
@@ -71,10 +70,6 @@ async function addNewDotnetProject(
     configuration.targets.test = GetTestExecutorConfig();
   }
   addProjectConfiguration(host, projectName, configuration);
-  await manipulateXmlProjectFile(host, {
-    projectName,
-    projectRoot,
-  });
 }
 
 async function getProjectFilesInWorkspace(host: Tree) {

--- a/packages/core/src/generators/init/generator.spec.ts
+++ b/packages/core/src/generators/init/generator.spec.ts
@@ -7,6 +7,11 @@ import { CONFIG_FILE_PATH, NxDotnetConfig } from '@nx-dotnet/utils';
 
 import generator from './generator';
 
+jest.mock('@nx-dotnet/utils', () => ({
+  ...jest.requireActual('@nx-dotnet/utils'),
+  resolve: jest.fn(() => 'check-module-boundaries.js'),
+}));
+
 describe('init generator', () => {
   let appTree: Tree;
   let dotnetClient: DotNetClient;
@@ -86,6 +91,10 @@ describe('init generator', () => {
 
     const hasTargetsFile = appTree.isFile('Directory.Build.targets');
     expect(hasTargetsFile).toBeTruthy();
+    const hasPreBuildTask = appTree
+      .read('Directory.Build.targets', 'utf-8')
+      ?.includes('check-module-boundaries.js');
+    expect(hasPreBuildTask).toBeTruthy();
   });
 
   it('should not add directory build props and targets files if props file exists', async () => {

--- a/packages/core/src/generators/init/generator.spec.ts
+++ b/packages/core/src/generators/init/generator.spec.ts
@@ -1,3 +1,4 @@
+import * as devkit from '@nrwl/devkit';
 import { readJson, Tree, writeJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
@@ -76,5 +77,24 @@ describe('init generator', () => {
     expect(updated.scripts.prepare).toBe(
       'npm run clean && npm run build && nx g @nx-dotnet/core:restore',
     );
+  });
+
+  it('should add directory build props and targets files', async () => {
+    await generator(appTree, null, dotnetClient);
+    const hasPropsFile = appTree.isFile('Directory.Build.props');
+    expect(hasPropsFile).toBeTruthy();
+
+    const hasTargetsFile = appTree.isFile('Directory.Build.targets');
+    expect(hasTargetsFile).toBeTruthy();
+  });
+
+  it('should not add directory build props and targets files if props file exists', async () => {
+    appTree.write('Directory.Build.props', '');
+    const spy = jest.spyOn(devkit, 'generateFiles');
+    await generator(appTree, null, dotnetClient);
+
+    expect(spy).not.toHaveBeenCalled();
+    const hasTargetsFile = appTree.isFile('Directory.Build.targets');
+    expect(hasTargetsFile).toBeFalsy();
   });
 });

--- a/packages/core/src/generators/init/generator.ts
+++ b/packages/core/src/generators/init/generator.ts
@@ -12,9 +12,15 @@ import {
 } from '@nrwl/devkit';
 
 import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
-import { CONFIG_FILE_PATH, isDryRun, NxDotnetConfig } from '@nx-dotnet/utils';
+import {
+  CONFIG_FILE_PATH,
+  isDryRun,
+  NxDotnetConfig,
+  resolve,
+} from '@nx-dotnet/utils';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import * as path from 'path';
+import { normalize, relative } from 'path';
 
 export async function initGenerator(
   host: Tree,
@@ -127,8 +133,16 @@ function addPrepareScript(host: Tree) {
 function initBuildCustomization(host: Tree) {
   const initialized = host.exists('Directory.Build.props');
   if (!initialized && !isDryRun()) {
+    const checkModuleBoundariesScriptPath = normalize(
+      relative(
+        host.root,
+        resolve('@nx-dotnet/core/src/tasks/check-module-boundaries'),
+      ),
+    );
+
     generateFiles(host, path.join(__dirname, 'templates/root'), '.', {
       tmpl: '',
+      checkModuleBoundariesScriptPath,
     });
   }
 }

--- a/packages/core/src/generators/init/generator.ts
+++ b/packages/core/src/generators/init/generator.ts
@@ -1,5 +1,6 @@
 import {
   addDependenciesToPackageJson,
+  generateFiles,
   GeneratorCallback,
   logger,
   NxJsonConfiguration,
@@ -13,6 +14,7 @@ import {
 import { DotNetClient, dotnetFactory } from '@nx-dotnet/dotnet';
 import { CONFIG_FILE_PATH, isDryRun, NxDotnetConfig } from '@nx-dotnet/utils';
 import type { PackageJson } from 'nx/src/utils/package-json';
+import * as path from 'path';
 
 export async function initGenerator(
   host: Tree,
@@ -41,6 +43,8 @@ export async function initGenerator(
   }
 
   initToolManifest(host, dotnetClient);
+
+  initBuildCustomization(host);
 
   return async () => {
     for (const task of tasks) {
@@ -118,4 +122,13 @@ function addPrepareScript(host: Tree) {
   packageJson.scripts ??= {};
   packageJson.scripts.prepare = prepareSteps.join(' && ');
   writeJson(host, 'package.json', packageJson);
+}
+
+function initBuildCustomization(host: Tree) {
+  const initialized = host.exists('Directory.Build.props');
+  if (!initialized && !isDryRun()) {
+    generateFiles(host, path.join(__dirname, 'templates/root'), '.', {
+      tmpl: '',
+    });
+  }
 }

--- a/packages/core/src/generators/init/generator.ts
+++ b/packages/core/src/generators/init/generator.ts
@@ -132,7 +132,7 @@ function addPrepareScript(host: Tree) {
 
 function initBuildCustomization(host: Tree) {
   const initialized = host.exists('Directory.Build.props');
-  if (!initialized && !isDryRun()) {
+  if (!initialized) {
     const checkModuleBoundariesScriptPath = normalize(
       relative(
         host.root,

--- a/packages/core/src/generators/init/templates/root/Directory.Build.props__tmpl__
+++ b/packages/core/src/generators/init/templates/root/Directory.Build.props__tmpl__
@@ -1,0 +1,17 @@
+<!-- 
+  This file is imported early in the build order. 
+  Use it to set default property values that can be overridden in specific projects.
+-->
+<Project>
+  <PropertyGroup>
+    <!-- Output path configuration -->
+    <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))</RepoRoot>
+    <ProjectRelativePath>$([System.IO.Path]::GetRelativePath($(RepoRoot), $(MSBuildProjectDirectory)))</ProjectRelativePath>
+    <BaseOutputPath>$(RepoRoot)dist/$(ProjectRelativePath)</BaseOutputPath>
+    <OutputPath>$(BaseOutputPath)</OutputPath>
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+  </PropertyGroup>
+</Project>

--- a/packages/core/src/generators/init/templates/root/Directory.Build.targets__tmpl__
+++ b/packages/core/src/generators/init/templates/root/Directory.Build.targets__tmpl__
@@ -1,0 +1,6 @@
+<!-- 
+  This file is imported late in the build order. 
+  Use it to override properties and define dependent properties.
+-->
+<Project>
+</Project>

--- a/packages/core/src/generators/init/templates/root/Directory.Build.targets__tmpl__
+++ b/packages/core/src/generators/init/templates/root/Directory.Build.targets__tmpl__
@@ -4,10 +4,10 @@
 -->
 <Project>
   <PropertyGroup>
-    <NxProjectName>$([System.IO.Path]::GetFileName($(MSBuildProjectDirectory)))</NxProjectName>
+    <MSBuildProjectDirRelativePath>$([System.IO.Path]::GetRelativePath($(RepoRoot), $(MSBuildProjectDirectory)))</MSBuildProjectDirRelativePath>
     <NodeModulesRelativePath>$([System.IO.Path]::GetRelativePath($(MSBuildProjectDirectory), $(RepoRoot)))</NodeModulesRelativePath>
   </PropertyGroup>
-  <Target Name="CheckNxModuleBoundaries" BeforeTargets="Build">    
-    <Exec Command="node $(NodeModulesRelativePath)/<%= checkModuleBoundariesScriptPath %> -p $(NxProjectName)"/>
+  <Target Name="CheckNxModuleBoundaries" BeforeTargets="Build">
+    <Exec Command="node $(NodeModulesRelativePath)/<%= checkModuleBoundariesScriptPath %> --project-root $(MSBuildProjectDirRelativePath)"/>
   </Target>
 </Project>

--- a/packages/core/src/generators/init/templates/root/Directory.Build.targets__tmpl__
+++ b/packages/core/src/generators/init/templates/root/Directory.Build.targets__tmpl__
@@ -3,4 +3,11 @@
   Use it to override properties and define dependent properties.
 -->
 <Project>
+  <PropertyGroup>
+    <NxProjectName>$([System.IO.Path]::GetFileName($(MSBuildProjectDirectory)))</NxProjectName>
+    <NodeModulesRelativePath>$([System.IO.Path]::GetRelativePath($(MSBuildProjectDirectory), $(RepoRoot)))</NodeModulesRelativePath>
+  </PropertyGroup>
+  <Target Name="CheckNxModuleBoundaries" BeforeTargets="Build">    
+    <Exec Command="node $(NodeModulesRelativePath)/<%= checkModuleBoundariesScriptPath %> -p $(NxProjectName)"/>
+  </Target>
 </Project>

--- a/packages/core/src/generators/lib/generator.spec.ts
+++ b/packages/core/src/generators/lib/generator.spec.ts
@@ -18,7 +18,6 @@ describe('nx-dotnet library generator', () => {
     language: 'C#',
     template: 'classlib',
     testTemplate: 'none',
-    skipOutputPathManipulation: true,
     standalone: false,
     projectType: 'library',
     skipSwaggerLib: true,

--- a/packages/core/src/generators/test/generator.spec.ts
+++ b/packages/core/src/generators/test/generator.spec.ts
@@ -17,7 +17,6 @@ describe('nx-dotnet test generator', () => {
     name: 'existing',
     testTemplate: 'xunit',
     language: 'C#',
-    skipOutputPathManipulation: true,
     standalone: false,
     pathScheme: 'nx',
   };

--- a/packages/core/src/generators/test/generator.ts
+++ b/packages/core/src/generators/test/generator.ts
@@ -25,7 +25,6 @@ export default async function (
     testProjectNameSuffix: options.suffix,
     name,
     language: options.language,
-    skipOutputPathManipulation: options.skipOutputPathManipulation,
     testTemplate: options.testTemplate,
     directory,
     tags: project.tags?.join(','),

--- a/packages/core/src/generators/test/schema.json
+++ b/packages/core/src/generators/test/schema.json
@@ -50,11 +50,6 @@
         "type": "string"
       }
     },
-    "skipOutputPathManipulation": {
-      "type": "boolean",
-      "description": "Skip XML changes for default build path",
-      "default": false
-    },
     "standalone": {
       "type": "boolean",
       "description": "Should the project use project.json? If false, the project config is inside workspace.json"

--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -7,6 +7,7 @@ import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
 
 import { NxDotnetProjectGeneratorSchema } from '../../models';
 import { GenerateProject } from './generate-project';
+import * as mockedGenerateTestProject from './generate-test-project';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -15,6 +16,8 @@ jest.mock('@nx-dotnet/utils', () => ({
   ...jest.requireActual('@nx-dotnet/utils'),
   resolve: jest.fn(() => 'check-module-boundaries.js'),
 }));
+
+jest.mock('./generate-test-project');
 
 describe('nx-dotnet project generator', () => {
   let appTree: Tree;
@@ -96,10 +99,19 @@ describe('nx-dotnet project generator', () => {
   });
 
   it('should generate test project', async () => {
+    const generateTestProject = (
+      mockedGenerateTestProject as jest.Mocked<typeof mockedGenerateTestProject>
+    ).GenerateTestProject;
+
     options.testTemplate = 'nunit';
     await GenerateProject(appTree, options, dotnetClient, 'application');
     const config = readProjectConfiguration(appTree, 'test');
     expect(config.targets?.serve).toBeDefined();
+    expect(generateTestProject).toHaveBeenCalledWith(
+      appTree,
+      expect.objectContaining(options),
+      dotnetClient,
+    );
   });
 
   it('should include lint target', async () => {

--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -11,6 +11,11 @@ import { GenerateProject } from './generate-project';
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 jest.spyOn(console, 'log').mockImplementation(() => {});
 
+jest.mock('@nx-dotnet/utils', () => ({
+  ...jest.requireActual('@nx-dotnet/utils'),
+  resolve: jest.fn(() => 'check-module-boundaries.js'),
+}));
+
 describe('nx-dotnet project generator', () => {
   let appTree: Tree;
   let dotnetClient: DotNetClient;
@@ -28,7 +33,6 @@ describe('nx-dotnet project generator', () => {
       language: 'C#',
       template: 'classlib',
       testTemplate: 'none',
-      skipOutputPathManipulation: true,
       standalone: false,
       skipSwaggerLib: true,
       projectType: 'application',

--- a/packages/core/src/generators/utils/generate-test-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-test-project.spec.ts
@@ -73,7 +73,6 @@ describe('nx-dotnet test project generator', () => {
       name: 'domain-existing-app',
       testTemplate: 'xunit',
       language: 'C#',
-      skipOutputPathManipulation: true,
       standalone: false,
       projectType: 'application',
       projectRoot: 'apps/domain/existing-app',

--- a/packages/core/src/generators/utils/generate-test-project.ts
+++ b/packages/core/src/generators/utils/generate-test-project.ts
@@ -1,7 +1,7 @@
 import { addProjectConfiguration, names, Tree } from '@nrwl/devkit';
 
 import { DotNetClient, dotnetNewOptions } from '@nx-dotnet/dotnet';
-import { findProjectFileInPath, isDryRun } from '@nx-dotnet/utils';
+import { isDryRun } from '@nx-dotnet/utils';
 
 import {
   GetBuildExecutorConfiguration,
@@ -9,11 +9,7 @@ import {
   GetTestExecutorConfig,
 } from '../../models';
 import { addToSolutionFile } from './add-to-sln';
-import {
-  manipulateXmlProjectFile,
-  NormalizedSchema,
-  normalizeOptions,
-} from './generate-project';
+import { NormalizedSchema, normalizeOptions } from './generate-project';
 export interface PathParts {
   suffix: string;
   separator: '.' | '-';
@@ -76,16 +72,5 @@ export async function GenerateTestProject(
   dotnetClient.new(schema.testTemplate, newParams);
   if (!isDryRun()) {
     addToSolutionFile(host, testRoot, dotnetClient, schema.solutionFile);
-  }
-
-  if (!isDryRun() && !schema.skipOutputPathManipulation) {
-    await manipulateXmlProjectFile(host, {
-      ...schema,
-      projectRoot: testRoot,
-      projectName: testProjectName,
-    });
-    const testCsProj = await findProjectFileInPath(testRoot);
-    const baseCsProj = await findProjectFileInPath(schema.projectRoot);
-    dotnetClient.addProjectReference(testCsProj, baseCsProj);
   }
 }

--- a/packages/core/src/generators/utils/generate-test-project.ts
+++ b/packages/core/src/generators/utils/generate-test-project.ts
@@ -1,7 +1,7 @@
 import { addProjectConfiguration, names, Tree } from '@nrwl/devkit';
 
 import { DotNetClient, dotnetNewOptions } from '@nx-dotnet/dotnet';
-import { isDryRun } from '@nx-dotnet/utils';
+import { findProjectFileInPath, isDryRun } from '@nx-dotnet/utils';
 
 import {
   GetBuildExecutorConfiguration,
@@ -72,5 +72,9 @@ export async function GenerateTestProject(
   dotnetClient.new(schema.testTemplate, newParams);
   if (!isDryRun()) {
     addToSolutionFile(host, testRoot, dotnetClient, schema.solutionFile);
+
+    const testCsProj = await findProjectFileInPath(testRoot);
+    const baseCsProj = await findProjectFileInPath(schema.projectRoot);
+    dotnetClient.addProjectReference(testCsProj, baseCsProj);
   }
 }

--- a/packages/core/src/models/project-generator-schema.ts
+++ b/packages/core/src/models/project-generator-schema.ts
@@ -11,7 +11,6 @@ export interface NxDotnetProjectGeneratorSchema {
   language: string;
   testTemplate: 'nunit' | 'mstest' | 'xunit' | 'none';
   testProjectNameSuffix?: string;
-  skipOutputPathManipulation: boolean;
   standalone: boolean;
   projectType?: ProjectType;
   solutionFile?: string | boolean;

--- a/packages/core/src/models/test-generator-schema.ts
+++ b/packages/core/src/models/test-generator-schema.ts
@@ -3,7 +3,6 @@ export interface NxDotnetTestGeneratorSchema {
   testTemplate: 'xunit' | 'nunit' | 'mstest';
   language: string;
   suffix?: string;
-  skipOutputPathManipulation: boolean;
   standalone: boolean;
   pathScheme: 'nx' | 'dotnet';
 }

--- a/packages/core/src/tasks/check-module-boundaries.ts
+++ b/packages/core/src/tasks/check-module-boundaries.ts
@@ -93,7 +93,6 @@ async function main() {
       project: 'p',
     },
   });
-  let nxProject = project;
   const workspace = new Workspaces(workspaceRoot);
   const workspaceJson: WorkspaceJsonConfiguration =
     workspace.readWorkspaceConfiguration();
@@ -112,6 +111,7 @@ async function main() {
   }
   // End Nx v12 support
 
+  let nxProject = project;
   // Find the associated nx project for the msbuild project directory.
   if (!project && projectRoot) {
     // Note that this returns the first matching project and would succeed for multiple (cs|fs...)proj under an nx project path,


### PR DESCRIPTION
## Adding msbuild customization files (#469 and #470)

Extending the `@nx-dotnet/core:init` generator to include initialization of MSBuild customization files `Directory.Build.props` and `Directory.Build.targets`. The targets file is a placeholder for workspaces to configure customization that should be imported later. The props file includes build output path properties equivalent to what is currently added per project via XML manipulation.  

Some remaining work:
- [x] **Update e2e tests**
- [ ]  **Documentation updates**
- [x]  **Verify idempotence expectation** - Do we need this for the targets file and props file independently or is treating them as a pair sufficient?
- [x] **Remove of the XML manipulation for setting of output paths** - What is the backwards compatibility expectation? OutputPath property in projects still needed if Directory.Build.* files are not present (e.g. in workspaces initialized with prior versions.)
- [ ] **Code coverage report path** - nx workspaces normally output reports to path like `coverage/apps/my-app`. This potentially can be configured in a property in `Directory.Build.props` as well
- [x] **CheckNxModuleBoundaries target** - this should be possible to handle in Directory.Build.targets