### PR TITLE
fix(core): check-module-boundaries logging msg should not log undefined

### DIFF
--- a/packages/core/src/tasks/check-module-boundaries.ts
+++ b/packages/core/src/tasks/check-module-boundaries.ts
@@ -132,7 +132,7 @@ async function main() {
     }
   }
 
-  console.log(`Checking module boundaries for ${project}`);
+  console.log(`Checking module boundaries for ${nxProject}`);
   const violations = await checkModuleBoundariesForProject(
     nxProject,
     workspaceJson,


### PR DESCRIPTION
Currently, the console log message will show `Checking module boundaries for undefined` in particular branches of the function.

This just uses the `nxProject` variable to log the console message which seems more appropriate.