### PR TITLE
fix(core): check-module-boundaries should not log undefined as project name

### DIFF
--- a/packages/core/src/tasks/check-module-boundaries.ts
+++ b/packages/core/src/tasks/check-module-boundaries.ts
@@ -132,7 +132,7 @@ async function main() {
     }
   }
 
-  console.log(`Checking module boundaries for ${project}`);
+  console.log(`Checking module boundaries for ${nxProject}`);
   const violations = await checkModuleBoundariesForProject(
     nxProject,
     workspaceJson,


### PR DESCRIPTION
The msg that is logged to the console should not log undefined.