### PR TITLE
fix(core): check-module-boundaries should work if single quotes not consumed by shell

### DIFF
--- a/packages/core/src/generators/init/templates/root/Directory.Build.targets__tmpl__
+++ b/packages/core/src/generators/init/templates/root/Directory.Build.targets__tmpl__
@@ -8,6 +8,6 @@
     <NodeModulesRelativePath>$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), $(RepoRoot)))</NodeModulesRelativePath>
   </PropertyGroup>
   <Target Name="CheckNxModuleBoundaries" BeforeTargets="Build">
-    <Exec Command="node $(NodeModulesRelativePath)/<%= checkModuleBoundariesScriptPath %> --project-root '$(MSBuildProjectDirRelativePath)'"/>
+    <Exec Command="node $(NodeModulesRelativePath)/<%= checkModuleBoundariesScriptPath %> --project-root &quot;$(MSBuildProjectDirRelativePath)&quot;"/>
   </Target>
 </Project>

--- a/packages/core/src/tasks/check-module-boundaries.spec.ts
+++ b/packages/core/src/tasks/check-module-boundaries.spec.ts
@@ -78,13 +78,10 @@ describe('enforce-module-boundaries', () => {
   it('should exit early if no tags on project', async () => {
     const spy = jest.spyOn(checkModule, 'loadModuleBoundaries');
     const results = await checkModuleBoundariesForProject('a', {
-      version: 2,
-      projects: {
-        a: {
-          tags: [],
-          targets: {},
-          root: '',
-        },
+      a: {
+        tags: [],
+        targets: {},
+        root: '',
       },
     });
     expect(spy).not.toHaveBeenCalled();

--- a/packages/utils/src/lib/utility-functions/workspace.ts
+++ b/packages/utils/src/lib/utility-functions/workspace.ts
@@ -2,8 +2,8 @@ import {
   getProjects,
   normalizePath as nxNormalizePath,
   ProjectConfiguration,
+  ProjectsConfigurations,
   Tree,
-  WorkspaceJsonConfiguration,
   workspaceRoot,
 } from '@nrwl/devkit';
 
@@ -27,7 +27,7 @@ export function getProjectFileForNxProjectSync(project: ProjectConfiguration) {
 
 export function getDependantProjectsForNxProject(
   targetProject: string,
-  workspaceConfiguration: WorkspaceJsonConfiguration,
+  projectsConfiguration: ProjectsConfigurations,
   forEachCallback?: (
     project: ProjectConfiguration & { projectFile: string },
     projectName: string,
@@ -39,14 +39,14 @@ export function getDependantProjectsForNxProject(
   const projectRoots: { [key: string]: string } = {};
   const dependantProjects: { [key: string]: ProjectConfiguration } = {};
 
-  Object.entries(workspaceConfiguration.projects).forEach(([name, project]) => {
+  Object.entries(projectsConfiguration.projects).forEach(([name, project]) => {
     projectRoots[name] = normalizePath(resolve(project.root));
   });
 
   const absoluteNetProjectFilePath = resolve(
     workspaceRoot,
     getProjectFileForNxProjectSync(
-      workspaceConfiguration.projects[targetProject],
+      projectsConfiguration.projects[targetProject],
     ),
   );
   const netProjectFilePath = relative(
@@ -74,7 +74,7 @@ export function getDependantProjectsForNxProject(
           if (forEachCallback) {
             forEachCallback(
               {
-                ...workspaceConfiguration.projects[dependency],
+                ...projectsConfiguration.projects[dependency],
                 projectFile: workspaceFilePath,
               },
               dependency,
@@ -82,7 +82,7 @@ export function getDependantProjectsForNxProject(
             );
           }
           dependantProjects[dependency] =
-            workspaceConfiguration.projects[dependency];
+            projectsConfiguration.projects[dependency];
         }
       });
     }),


### PR DESCRIPTION
check-module-boundaries is failing on windows since single quotes are not consumed by the shell before passing into yargs.