### PR TITLE
feat(core): add the ability to forward arguments to dotnet new

### DIFF
--- a/docs/core/generators/application.md
+++ b/docs/core/generators/application.md
@@ -47,3 +47,11 @@ Generate a dotnet project under the application directory.
 ### pathScheme
 
 - (string): Determines if the project should follow NX or dotnet path naming conventions
+
+### args
+
+- (array): Additional arguments to pass to the dotnet command. For example: &#34;nx g @nx-dotnet/core:app myapp --args=&#39;--no-restore&#39;&#34; Arguments can also be appended to the end of the command using &#39;--&#39;. For example, &#39;nx g @nx-dotnet/core:app myapp -- --no-restore&#39;.
+
+### \_
+
+- (array):

--- a/packages/core/src/generators/app/schema.json
+++ b/packages/core/src/generators/app/schema.json
@@ -92,6 +92,22 @@
           { "value": "dotnet", "label": "Dotnet naming conventions" }
         ]
       }
+    },
+    "args": {
+      "type": "array",
+      "description": "Additional arguments to pass to the dotnet command. For example: \"nx g @nx-dotnet/core:app myapp --args='--no-restore'\" Arguments can also be appended to the end of the command using '--'. For example, 'nx g @nx-dotnet/core:app myapp -- --no-restore'.",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "_": {
+      "type": "array",
+      "hidden": true,
+      "items": {
+        "type": "string"
+      },
+      "default": []
     }
   },
   "required": ["name", "language"]

--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -38,6 +38,8 @@ describe('nx-dotnet project generator', () => {
       skipSwaggerLib: true,
       projectType: 'application',
       pathScheme: 'nx',
+      _: [],
+      args: [],
     };
 
     jest.spyOn(dotnetClient, 'listInstalledTemplates').mockReturnValue([
@@ -122,6 +124,18 @@ describe('nx-dotnet project generator', () => {
     const [, dotnetOptions] = spy.mock.calls[spy.mock.calls.length - 1];
     const nameFlag = dotnetOptions?.name;
     expect(nameFlag).toBe('Proj.SubDir.Test');
+  });
+
+  it('should forward args to dotnet new', async () => {
+    options._ = ['--foo', 'bar'];
+    options.args = ['--help'];
+    const spy = jest.spyOn(dotnetClient, 'new');
+    await GenerateProject(appTree, options, dotnetClient, 'library');
+    const [, , additionalArguments] = spy.mock.calls[spy.mock.calls.length - 1];
+    expect(additionalArguments).toEqual(
+      expect.arrayContaining(['--help', '--foo', 'bar']),
+    );
+    expect(additionalArguments).toHaveLength(3);
   });
 
   describe('swagger library', () => {

--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -202,11 +202,24 @@ export async function GenerateProject(
     output: normalizedOptions.projectRoot,
   };
 
+  // Combine appended arguments with the ones that are passed in through the args property.
+  const additionalArguments = [];
+  if (options.args) {
+    additionalArguments.push(...options.args);
+  }
+  if (options._) {
+    additionalArguments.push(...options._);
+  }
+
   if (isDryRun()) {
     newParams['dryRun'] = true;
   }
 
-  dotnetClient.new(normalizedOptions.projectTemplate, newParams);
+  dotnetClient.new(
+    normalizedOptions.projectTemplate,
+    newParams,
+    additionalArguments,
+  );
   if (!isDryRun()) {
     addToSolutionFile(
       host,

--- a/packages/core/src/models/project-generator-schema.ts
+++ b/packages/core/src/models/project-generator-schema.ts
@@ -16,4 +16,8 @@ export interface NxDotnetProjectGeneratorSchema {
   solutionFile?: string | boolean;
   skipSwaggerLib: boolean;
   pathScheme: 'nx' | 'dotnet';
+  /** The additional arguments passed to the generate command are stored here if appended to the end some reason. Ex: "nx g @nx-dotnet/core:app my-app -- --force --no-restore" would result in an array with ['--force', '--no-restore'] */
+  _?: string[];
+  /** Another location for the arguments to be forwarded to the dotnet command. Useful to allow it to show up in the UI */
+  args?: string[];
 }

--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -27,12 +27,17 @@ import { LoadedCLI } from './dotnet.factory';
 export class DotNetClient {
   constructor(private cliCommand: LoadedCLI, public cwd?: string) {}
 
-  new(template: KnownDotnetTemplates, parameters?: dotnetNewOptions): void {
+  new(
+    template: KnownDotnetTemplates,
+    parameters?: dotnetNewOptions,
+    additionalArguments?: string[],
+  ): void {
     const params = [`new`, template];
     if (parameters) {
       parameters = swapKeysUsingMap(parameters, newKeyMap);
       params.push(...getSpawnParameterArray(parameters));
     }
+    params.push(...(additionalArguments || []));
     return this.logAndExecute(params);
   }
 


### PR DESCRIPTION
This PR adds the ability to forward arguments to the `dotnet new` command.

This can be done with either the `--args` parameter or by appending to the end of the generate command with `--`.

This method could also be applied for any situation where it would be beneficial to forward arguments to the invoked command

Fixes: #262 
Fixes: #398 