### PR TITLE
fix(core): prevent stale cache entries from breaking swagger on dotnet upgrades

### DIFF
--- a/demo/apps/webapi/NxDotnet.Test.Webapi.csproj
+++ b/demo/apps/webapi/NxDotnet.Test.Webapi.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/demo/apps/webapi/Program.cs
+++ b/demo/apps/webapi/Program.cs
@@ -3,7 +3,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 
 builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+// Learn more about configuring Swagger at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 

--- a/demo/libs/csharp-models/NxDotnet.Demo.Libs.CsharpModels.csproj
+++ b/demo/libs/csharp-models/NxDotnet.Demo.Libs.CsharpModels.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "rollForward": "latestMinor",
-    "version": "6.0.400"
-  }
-}

--- a/packages/core/src/generators/utils/get-path-to-startup-assembly.ts
+++ b/packages/core/src/generators/utils/get-path-to-startup-assembly.ts
@@ -37,8 +37,8 @@ export function buildStartupAssemblyPath(
     /(?:\.csproj|\.vbproj|\.fsproj)$/,
     '.dll',
   );
-  const foundDll = sync(`**/${dllName}`, { cwd: outputDirectory })[0];
-  if (!foundDll) {
+  const matchingDlls = sync(`**/${dllName}`, { cwd: outputDirectory });
+  if (!matchingDlls.length) {
     throw new Error(
       `[nx-dotnet] Unable to locate ${dllName} in ${relative(
         workspaceRoot,
@@ -46,10 +46,15 @@ export function buildStartupAssemblyPath(
       )}`,
     );
   }
-  return joinPathFragments(
-    outputDirectory,
-    sync(`**/${dllName}`, { cwd: outputDirectory })[0],
-  );
+  if (matchingDlls.length > 1) {
+    throw new Error(
+      `[nx-dotnet] Located multiple matching dlls for ${projectName}.
+
+You may need to clean old build artifacts from your outputs, or manually
+specify the path to the output assembly within ${project.root}/project.json.`,
+    );
+  }
+  return joinPathFragments(outputDirectory, matchingDlls[0]);
 }
 
 function findBuildTarget(

--- a/packages/utils/src/lib/utility-functions/workspace.ts
+++ b/packages/utils/src/lib/utility-functions/workspace.ts
@@ -8,6 +8,7 @@ import {
 } from '@nrwl/devkit';
 
 import { readFileSync } from 'fs';
+import { NX_PREFIX } from 'nx/src/utils/logger';
 import { dirname, isAbsolute, relative, resolve } from 'path';
 import { XmlDocument, XmlElement } from 'xmldoc';
 
@@ -134,4 +135,17 @@ export function getProjectFilesForProject(
  */
 function normalizePath(p: string): string {
   return nxNormalizePath(p).split('\\').join('/');
+}
+
+export function inlineNxTokens(value: string, project: ProjectConfiguration) {
+  if (value.startsWith('{workspaceRoot}/')) {
+    value = value.replace(/^\{workspaceRoot\}\//, '');
+  }
+  if (value.includes('{workspaceRoot}')) {
+    throw new Error(
+      `${NX_PREFIX} The {workspaceRoot} token is only valid at the beginning of an output.`,
+    );
+  }
+  value = value.replace('{projectRoot}', project.root);
+  return value.replace('{projectName}', project.name as string);
 }


### PR DESCRIPTION
## Root Cause Analysis

Hit a weird issue when updating to .NET 7.

- Updating .NET changes the subdir within output path that contains your code (e.g. dist/apps/my-api/bin/net7.0 instead of dist/apps/my-api/bin/net6.0).
- We infer the path to your output when extracting swagger documentation, by globbing for .dll files that match your project's name inside of the root dist folder and using the first match. (e.g. glob(dist/apps/my-api/**/my-api.dll)[0])
- If you don't remember to clean the dist folder, the .NET build's old results end up in the nx cache.

All of the above combined get you a poisoned cache for nx build my-api that causes nx swagger my-api to fail.

## Fix

- swagger executor will error appropriately when it finds multiple matching DLLs, instead of using the first silently. If you target is meant to create multiple DLLs that would match the glob we use, you can and should manually specify the assembly path in project.json.
- build executor should clean old artifacts to prevent bad cache entries from cropping up.