### PR TITLE
fix(core): app swaggerLib generation should work using dotnet pathScheme

### DIFF
--- a/e2e/core-e2e/tests/nx-dotnet.spec.ts
+++ b/e2e/core-e2e/tests/nx-dotnet.spec.ts
@@ -487,18 +487,20 @@ public class UnitTest1
 
     it('should generate swagger project using dotnet pathScheme', async () => {
       const apiName = uniq('CurveDental.Foobar.SomeApi');
-      const apiNxFileName = names(apiName).fileName;
+      const apiNxProjectName = names(apiName).fileName;
       await runNxCommandAsync(
         `generate @nx-dotnet/core:app ${apiName} --language="C#" --pathScheme=dotnet --template="webapi" --skipSwaggerLib=false`,
       );
 
       expect(() => checkFilesExist(`apps/${apiName}`)).not.toThrow();
       expect(() =>
-        checkFilesExist(`libs/generated/${apiNxFileName}-swagger`),
+        checkFilesExist(`libs/generated/${apiNxProjectName}-swagger`),
       ).not.toThrow();
       expect(() => runNxCommand(`swagger ${apiName}`)).not.toThrow();
       expect(() =>
-        checkFilesExist(`libs/generated/${apiNxFileName}-swagger/swagger.json`),
+        checkFilesExist(
+          `libs/generated/${apiNxProjectName}-swagger/swagger.json`,
+        ),
       ).not.toThrow();
     });
   });

--- a/e2e/core-e2e/tests/nx-dotnet.spec.ts
+++ b/e2e/core-e2e/tests/nx-dotnet.spec.ts
@@ -442,7 +442,7 @@ public class UnitTest1
     [Fact]
     public void Test1()
     {
-      Assert.Equal(1, 2)
+      Assert.Equal(1, 2);
     }
 }`,
       );

--- a/e2e/core-e2e/tests/nx-dotnet.spec.ts
+++ b/e2e/core-e2e/tests/nx-dotnet.spec.ts
@@ -484,6 +484,23 @@ public class UnitTest1
         checkFilesExist(`libs/generated/${api}-swagger/swagger.json`),
       ).not.toThrow();
     });
+
+    it('should generate swagger project using dotnet pathScheme', async () => {
+      const apiName = uniq('CurveDental.Foobar.SomeApi');
+      const apiNxFileName = names(apiName).fileName;
+      await runNxCommandAsync(
+        `generate @nx-dotnet/core:app ${apiName} --language="C#" --pathScheme=dotnet --template="webapi" --skipSwaggerLib=false`,
+      );
+
+      expect(() => checkFilesExist(`apps/${apiName}`)).not.toThrow();
+      expect(() =>
+        checkFilesExist(`libs/generated/${apiNxFileName}-swagger`),
+      ).not.toThrow();
+      expect(() => runNxCommand(`swagger ${apiName}`)).not.toThrow();
+      expect(() =>
+        checkFilesExist(`libs/generated/${apiNxFileName}-swagger/swagger.json`),
+      ).not.toThrow();
+    });
   });
 });
 

--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -44,7 +44,7 @@ export interface NormalizedSchema
   parsedTags: string[];
   className: string;
   namespaceName: string;
-  nxFileName: string;
+  nxProjectName: string;
   projectType?: ProjectType;
 }
 
@@ -69,7 +69,7 @@ export async function normalizeOptions(
   const parsedTags = getProjectTagsFromSchema(options);
   const template = await getTemplate(options, client);
   const namespaceName = getNamespaceFromSchema(host, options, projectDirectory);
-  const nxFileName = names(options.name).fileName;
+  const nxProjectName = names(options.name).fileName;
 
   return {
     ...options,
@@ -82,7 +82,7 @@ export async function normalizeOptions(
     projectLanguage: options.language,
     projectTemplate: template as KnownDotnetTemplates,
     namespaceName,
-    nxFileName,
+    nxProjectName,
     projectType: projectType ?? options.projectType ?? 'library',
   };
 }
@@ -235,8 +235,8 @@ export async function GenerateProject(
     tasks.push(
       await generateSwaggerSetup(host, {
         project: normalizedOptions.projectName,
-        swaggerProject: `${normalizedOptions.nxFileName}-swagger`,
-        codegenProject: `${normalizedOptions.nxFileName}-types`,
+        swaggerProject: `${normalizedOptions.nxProjectName}-swagger`,
+        codegenProject: `${normalizedOptions.nxProjectName}-types`,
         useNxPluginOpenAPI: normalizedOptions.useNxPluginOpenAPI,
       }),
     );

--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -44,6 +44,7 @@ export interface NormalizedSchema
   parsedTags: string[];
   className: string;
   namespaceName: string;
+  nxFileName: string;
   projectType?: ProjectType;
 }
 
@@ -68,6 +69,7 @@ export async function normalizeOptions(
   const parsedTags = getProjectTagsFromSchema(options);
   const template = await getTemplate(options, client);
   const namespaceName = getNamespaceFromSchema(host, options, projectDirectory);
+  const nxFileName = names(options.name).fileName;
 
   return {
     ...options,
@@ -80,6 +82,7 @@ export async function normalizeOptions(
     projectLanguage: options.language,
     projectTemplate: template as KnownDotnetTemplates,
     namespaceName,
+    nxFileName,
     projectType: projectType ?? options.projectType ?? 'library',
   };
 }
@@ -232,8 +235,8 @@ export async function GenerateProject(
     tasks.push(
       await generateSwaggerSetup(host, {
         project: normalizedOptions.projectName,
-        swaggerProject: `${normalizedOptions.projectName}-swagger`,
-        codegenProject: `${normalizedOptions.projectName}-types`,
+        swaggerProject: `${normalizedOptions.nxFileName}-swagger`,
+        codegenProject: `${normalizedOptions.nxFileName}-types`,
         useNxPluginOpenAPI: normalizedOptions.useNxPluginOpenAPI,
       }),
     );

--- a/packages/core/src/generators/utils/generate-test-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-test-project.spec.ts
@@ -91,7 +91,7 @@ describe('nx-dotnet test project generator', () => {
       skipSwaggerLib: true,
       className: 'DomainExistingApp',
       namespaceName: 'Domain.ExistingApp',
-      nxFileName: 'domain-existing-app',
+      nxProjectName: 'domain-existing-app',
       pathScheme: 'nx',
     };
     testProjectName = options.name + '-test';

--- a/packages/core/src/generators/utils/generate-test-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-test-project.spec.ts
@@ -91,6 +91,7 @@ describe('nx-dotnet test project generator', () => {
       skipSwaggerLib: true,
       className: 'DomainExistingApp',
       namespaceName: 'Domain.ExistingApp',
+      nxFileName: 'domain-existing-app',
       pathScheme: 'nx',
     };
     testProjectName = options.name + '-test';


### PR DESCRIPTION
codegenProject is generated using nrwl/js which applies nx file naming conventions. Codegen/swagger projects are json/ts libraries so they don't really have to follow dotnet conventions. This adds new nxProjectName normalized option in project generator. This filename is not affected by pathScheme and is used for swaggerProject and codegenProject

fixes https://github.com/nx-dotnet/nx-dotnet/issues/627