### PR TITLE
feat(core): extra parameters support for run tool

### DIFF
--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -196,6 +196,7 @@ export class DotNetClient {
     tool: string,
     positionalParameters?: string[],
     parameters?: T,
+    extraParameters?: string,
   ) {
     const params = ['tool', 'run', tool];
 
@@ -205,6 +206,11 @@ export class DotNetClient {
 
     if (parameters) {
       params.push(...getSpawnParameterArray(parameters));
+    }
+
+    if (extraParameters) {
+      const matches = extraParameters.match(EXTRA_PARAMS_REGEX);
+      params.push(...(matches as string[]));
     }
 
     return this.logAndExecute(params);


### PR DESCRIPTION
Fix #657

Example usage in custom executor:

```ts
const { name, context, project, outputDir, additionalArguments } = options;
const projectDir = normalizePath(dirname(projectFile));
const paramaters = {
    'startup-project': pathResolve(workspaceRoot, projectDir),
    'project': pathResolve(workspaceRoot, project),
    'context': context,
    'msbuildprojectextensionspath': pathResolve(workspaceRoot, `./dist/intermediates/${project}/obj`)
}
if (outputDir) {
    paramaters['output-dir'] = pathResolve(workspaceRoot, outputDir)
}
let extraParameters;
if (additionalArguments) {
    extraParameters = `-- ${additionalArguments}`;
}
dotnetClient.runTool('dotnet-ef', ['migrations', 'add', name ], paramaters, extraParameters);
```

With a target like this:

```ts
"ef-migrations": {
  "executor": "@org/dotnet-ef:migrations",
  "options": {
    "context": "AppDbContext",
    "project": "src/Shared.EventBus.IntegrationTests",
    "outputDir": "src/Shared.EventBus.IntegrationTests/Persistence/Migrations/EventBus",
    "additionalArguments": "-- Schema=test Assembly=Shared.EventBus.IntegrationTests"
  }
}
```