### PR TITLE
fix(core): use for of on loop on project Map

### DIFF
--- a/packages/core/src/migrations/1.8.0/remove-output-option.spec.ts
+++ b/packages/core/src/migrations/1.8.0/remove-output-option.spec.ts
@@ -10,10 +10,13 @@ import * as utils from '@nx-dotnet/utils';
 
 import update from './remove-output-option';
 
+const projects = new Map();
+
 jest.mock('@nx-dotnet/utils', () => ({
   ...(jest.requireActual('@nx-dotnet/utils') as typeof utils),
   getProjectFileForNxProject: () =>
     Promise.resolve('apps/my-app/my-app.csproj'),
+  getNxDotnetProjects: () => projects,
 }));
 
 describe('remove-output-option', () => {
@@ -33,6 +36,18 @@ describe('remove-output-option', () => {
       </Root>`,
     );
 
+    projects.clear();
+    projects.set('my-app', {
+      root: 'apps/my-app',
+      targets: {
+        build: {
+          executor: '@nx-dotnet/core:build',
+          options: {
+            output: 'dist/apps/my-app',
+          },
+        },
+      },
+    });
     addProjectConfiguration(tree, 'my-app', {
       root: 'apps/my-app',
       targets: {
@@ -63,6 +78,19 @@ describe('remove-output-option', () => {
       </Root>`,
     );
 
+    projects.clear();
+    projects.set('my-app', {
+      root: 'apps/my-app',
+      targets: {
+        build: {
+          executor: '@nx-dotnet/core:build',
+          outputs: ['{options.output}'],
+          options: {
+            output: 'dist/apps/my-app',
+          },
+        },
+      },
+    });
     addProjectConfiguration(tree, 'my-app', {
       root: 'apps/my-app',
       targets: {
@@ -96,6 +124,18 @@ describe('remove-output-option', () => {
       </Root>`,
     );
 
+    projects.clear();
+    projects.set('my-app', {
+      root: 'apps/my-app',
+      targets: {
+        build: {
+          executor: '@nx-dotnet/core:build',
+          options: {
+            output: 'dist/apps/my-app',
+          },
+        },
+      },
+    });
     addProjectConfiguration(tree, 'my-app', {
       root: 'apps/my-app',
       targets: {

--- a/packages/utils/src/lib/utility-functions/workspace.ts
+++ b/packages/utils/src/lib/utility-functions/workspace.ts
@@ -97,9 +97,7 @@ export async function getNxDotnetProjects(
 ): Promise<Map<string, ProjectConfiguration>> {
   const allProjects = getProjects(host);
 
-  for (const key in allProjects) {
-    const p = allProjects.get(key);
-
+  for (const [key, p] of allProjects) {
     let isNetProject = false;
     for (const pattern of ['*.csproj', '*.fsproj', '*.vbproj'] as const) {
       const matches = await glob(pattern, p?.root);


### PR DESCRIPTION
Fixes https://github.com/nx-dotnet/nx-dotnet/issues/646

Turns out the loop was being skipped over. In JS `for in` will not iterate a Map. Switched to a `for of` loop.

NOTES:

Have a unit test but did not include it because fast glob is running against the file system so the unit test is rigged.
fast glob is supposed to support an `fs` option to use an alternative file system, however, I could not get this to work with tree. Adding a virtual file system was out of scope since this is a single line fix.

 