### PR TITLE
fix(dotnet): update args handling for dotnet format

### DIFF
--- a/e2e/core-e2e/tests/nx-dotnet.spec.ts
+++ b/e2e/core-e2e/tests/nx-dotnet.spec.ts
@@ -35,6 +35,10 @@ describe('nx-dotnet e2e', () => {
     initializeGitRepo(e2eDir);
   }, 1500000);
 
+  afterEach(() => {
+    runNxCommand('reset');
+  });
+
   it('should initialize workspace build customization', async () => {
     await runNxCommandAsync(`generate @nx-dotnet/core:init`);
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ts-node": "ts-node",
     "rimraf": "rimraf",
     "preinstall": "node ./tools/scripts/hooks/preinstall.js",
+    "postinstall": "dotnet tool restore",
     "documentation:check": "ts-node ./tools/scripts/hooks/documentation.check.ts",
     "documentation": "nx g @nx-dotnet/nxdoc:generate-docs",
     "publish-dev": "ts-node tools/scripts/publish-dev",

--- a/packages/core/src/graph/process-project-graph.ts
+++ b/packages/core/src/graph/process-project-graph.ts
@@ -34,9 +34,7 @@ function visitProject(
   try {
     projectFile = getProjectFileForNxProjectSync(project);
   } catch (e) {
-    if (process.env['NX_VERBOSE_LOGGING'] === 'true') {
-      console.error(e);
-    }
+    // not a .NET project
   }
   if (projectFile !== null) {
     getDependantProjectsForNxProject(

--- a/packages/dotnet/src/lib/core/dotnet.client.spec.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.spec.ts
@@ -158,4 +158,298 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
       }
     });
   });
+
+  describe('format', () => {
+    it('should call subcommands properly when on .NET 6 and passing --fixWhitespace', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.format('my-project', {
+        fixWhitespace: false,
+      });
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            Array [
+              "format",
+              "style",
+              "my-project",
+            ],
+          ],
+          Array [
+            Array [
+              "format",
+              "analyzers",
+              "my-project",
+            ],
+          ],
+        ]
+      `);
+    });
+
+    it('should call subcommands properly when on .NET 6 and passing --fixAnalyzers', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.format('my-project', {
+        fixAnalyzers: false,
+      });
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            Array [
+              "format",
+              "whitespace",
+              "my-project",
+            ],
+          ],
+          Array [
+            Array [
+              "format",
+              "style",
+              "my-project",
+            ],
+          ],
+        ]
+      `);
+    });
+
+    it('should call subcommands properly when on .NET 6 and passing --fixAnalyzers severity', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.format('my-project', {
+        fixAnalyzers: 'warn',
+      });
+      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            Array [
+              "format",
+              "whitespace",
+              "my-project",
+            ],
+          ],
+          Array [
+            Array [
+              "format",
+              "style",
+              "my-project",
+            ],
+          ],
+          Array [
+            Array [
+              "format",
+              "analyzers",
+              "my-project",
+              "--severity",
+              "warn",
+            ],
+          ],
+        ]
+      `);
+    });
+
+    it('should call subcommands properly when on .NET 6 and passing --fixStyle', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.format('my-project', {
+        fixStyle: false,
+      });
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            Array [
+              "format",
+              "whitespace",
+              "my-project",
+            ],
+          ],
+          Array [
+            Array [
+              "format",
+              "analyzers",
+              "my-project",
+            ],
+          ],
+        ]
+      `);
+    });
+
+    it('should call subcommands properly when on .NET 6 and passing --fixAnalyzers severity', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.format('my-project', {
+        fixStyle: 'warn',
+      });
+      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            Array [
+              "format",
+              "whitespace",
+              "my-project",
+            ],
+          ],
+          Array [
+            Array [
+              "format",
+              "style",
+              "my-project",
+              "--severity",
+              "warn",
+            ],
+          ],
+          Array [
+            Array [
+              "format",
+              "analyzers",
+              "my-project",
+            ],
+          ],
+        ]
+      `);
+    });
+
+    it('should not pass `check` flag when on .NET 6', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.format('my-project', {
+        check: true,
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            Array [
+              "format",
+              "my-project",
+              "--verify-no-changes",
+            ],
+          ],
+        ]
+      `);
+    });
+
+    it('should call single command when on .NET 6 and not passing any options', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.format('my-project');
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            Array [
+              "format",
+              "my-project",
+            ],
+          ],
+        ]
+      `);
+    });
+
+    it('should call single command when on .NET 5 and not passing any options', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('5.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.format('my-project');
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            Array [
+              "format",
+              "my-project",
+            ],
+          ],
+        ]
+      `);
+    });
+
+    it('should call single command when on .NET 5 if passing --fixWhitespace', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('5.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.format('my-project', {
+        fixWhitespace: false,
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            Array [
+              "format",
+              "my-project",
+              "--fix-whitespace",
+              "false",
+            ],
+          ],
+        ]
+      `);
+    });
+
+    it('should call single command when on .NET 5 if passing --fixStyle', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('5.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.format('my-project', {
+        fixStyle: false,
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            Array [
+              "format",
+              "my-project",
+              "--fix-style",
+              "false",
+            ],
+          ],
+        ]
+      `);
+    });
+
+    it('should call single command when on .NET 5 if passing --fixAnalyzers', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('5.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.format('my-project', {
+        fixAnalyzers: false,
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            Array [
+              "format",
+              "my-project",
+              "--fix-analyzers",
+              "false",
+            ],
+          ],
+        ]
+      `);
+    });
+  });
 });

--- a/packages/dotnet/src/lib/core/dotnet.factory.ts
+++ b/packages/dotnet/src/lib/core/dotnet.factory.ts
@@ -31,8 +31,11 @@ export function dotnetFactory(): LoadedCLI {
   }
 }
 
-export function mockDotnetFactory(): LoadedCLI {
-  return { command: 'echo', info: { global: true, version: '6.0.100' } };
+export function mockDotnetFactory(version?: string): LoadedCLI {
+  return {
+    command: 'echo',
+    info: { global: true, version: version ?? '6.0.100' },
+  };
 }
 
 export type LoadedCLI = {

--- a/packages/utils/src/lib/utility-functions/parameters.ts
+++ b/packages/utils/src/lib/utility-functions/parameters.ts
@@ -27,15 +27,14 @@ export function getParameterString(
 export function getSpawnParameterArray(
   parameters: Record<string, boolean | string>,
 ): string[] {
-  return Object.entries(parameters).reduce((acc, [flag, value]) => {
-    if (typeof value === 'boolean' || !value) {
-      if (value) {
-        return [...acc, `--${flag}`];
-      } else {
-        return acc;
-      }
-    } else {
-      return [...acc, `--${flag}`, value.toString()];
+  const spawnArray: string[] = [];
+  for (const [key, value] of Object.entries(parameters)) {
+    // true booleans are flags, explicit false booleans follow regular key-value pattern
+    if (typeof value === 'boolean' && value) {
+      spawnArray.push(`--${key}`);
+    } else if (value !== undefined && value !== null) {
+      spawnArray.push(`--${key}`, value.toString());
     }
-  }, new Array<string>());
+  }
+  return spawnArray;
 }

--- a/tools/scripts/e2e.ts
+++ b/tools/scripts/e2e.ts
@@ -18,12 +18,18 @@ async function runTest() {
 
   let testNamePattern = '';
   if (process.argv[3] === '-t' || process.argv[3] === '--testNamePattern') {
-    testNamePattern = `--testNamePattern "${process.argv[4]}"`;
+    testNamePattern = `-t '${process.argv[4]}'`;
   }
 
   if (process.argv[3] === 'affected') {
     const affected = execSync(
       `npx nx print-affected --base=origin/master --select=projects`,
+      {
+        env: {
+          ...process.env,
+          NX_DAEMON: 'false',
+        },
+      },
     )
       .toString()
       .split(',')


### PR DESCRIPTION
Updates dotnet client's format method to handle passing new args format that was introduced when the tool was brought into the dotnet CLI

This includes running 1-3 commands as needed rather than a single command since they no longer support disabling a single class of failure

Fixes: #623