### PR TITLE
feat(core): add argument forwarding to dotnet new

### DIFF
--- a/docs/core/generators/application.md
+++ b/docs/core/generators/application.md
@@ -47,3 +47,11 @@ Generate a dotnet project under the application directory.
 ### useNxPluginOpenAPI
 
 - (boolean): If using a codegen project, use openapi-generator
+
+### args
+
+- (array): Additional arguments to pass to the dotnet command. For example: &#34;nx g @nx-dotnet/core:app myapp --args=&#39;--no-restore&#39;&#34; Arguments can also be appended to the end of the command using &#39;--&#39;. For example, &#39;nx g @nx-dotnet/core:app myapp -- --no-restore&#39;.
+
+### **unparsed**
+
+- (array):

--- a/e2e/core-e2e/tests/nx-dotnet.spec.ts
+++ b/e2e/core-e2e/tests/nx-dotnet.spec.ts
@@ -15,16 +15,17 @@ import {
   uniq,
   updateFile,
 } from '@nrwl/nx-plugin/testing';
-import { runCommandUntil } from '../../utils';
+import { Workspaces } from '@nrwl/tao/src/shared/workspace';
 
+import { exec, execSync } from 'child_process';
 import { unlinkSync, writeFileSync } from 'fs';
+import { ensureDirSync } from 'fs-extra';
 import { join } from 'path';
 import { XmlDocument } from 'xmldoc';
 
 import { readDependenciesFromNxDepGraph } from '@nx-dotnet/utils/e2e';
-import { exec, execSync } from 'child_process';
-import { ensureDirSync } from 'fs-extra';
-import { Workspaces } from '@nrwl/tao/src/shared/workspace';
+
+import { runCommandUntil } from '../../utils';
 
 const e2eDir = tmpProjPath();
 
@@ -114,6 +115,18 @@ describe('nx-dotnet e2e', () => {
       expect(() => checkFilesExist(`apps/${app}`)).not.toThrow();
       expect(() =>
         checkFilesExist(`libs/generated/${app}-swaggger/project.json`),
+      ).toThrow();
+    });
+
+    it('should generate an app without launchSettings.json', async () => {
+      const app = uniq('app');
+      await runNxCommandAsync(
+        `generate @nx-dotnet/core:app ${app} --language="C#" --template="webapi" --args="--exclude-launch-settings=true"`,
+      );
+
+      expect(() => checkFilesExist(`apps/${app}`)).not.toThrow();
+      expect(() =>
+        checkFilesExist(`apps/${app}/Properties/launchSettings.json`),
       ).toThrow();
     });
 

--- a/packages/core/src/generators/app/schema.json
+++ b/packages/core/src/generators/app/schema.json
@@ -90,7 +90,27 @@
     "useNxPluginOpenAPI": {
       "type": "boolean",
       "description": "If using a codegen project, use openapi-generator"
+    },
+    "args": {
+      "type": "array",
+      "description": "Additional arguments to pass to the dotnet command. For example: \"nx g @nx-dotnet/core:app myapp --args='--no-restore'\" Arguments can also be appended to the end of the command using '--'. For example, 'nx g @nx-dotnet/core:app myapp -- --no-restore'.",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "__unparsed__": {
+      "hidden": true,
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "$default": {
+        "$source": "unparsed"
+      },
+      "x-priority": "internal"
     }
   },
+  "additionalProperties": true,
   "required": ["name", "language"]
 }

--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -2,11 +2,12 @@ import { readProjectConfiguration, Tree, writeJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
 import { DotNetClient, mockDotnetFactory } from '@nx-dotnet/dotnet';
-import path = require('path');
 
 import { NxDotnetProjectGeneratorSchema } from '../../models';
 import { GenerateProject } from './generate-project';
 import * as mockedGenerateTestProject from './generate-test-project';
+
+import path = require('path');
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -38,6 +39,8 @@ describe('nx-dotnet project generator', () => {
       skipSwaggerLib: true,
       projectType: 'application',
       pathScheme: 'nx',
+      __unparsed__: [],
+      args: [],
     };
 
     jest.spyOn(dotnetClient, 'listInstalledTemplates').mockReturnValue([
@@ -124,6 +127,18 @@ describe('nx-dotnet project generator', () => {
     const [, dotnetOptions] = spy.mock.calls[spy.mock.calls.length - 1];
     const nameFlag = dotnetOptions?.name;
     expect(nameFlag).toBe('Proj.SubDir.Test');
+  });
+
+  it('should forward args to dotnet new', async () => {
+    options.__unparsed__ = ['--foo', 'bar'];
+    options.args = ['--help'];
+    const spy = jest.spyOn(dotnetClient, 'new');
+    await GenerateProject(appTree, options, dotnetClient, 'library');
+    const [, , additionalArguments] = spy.mock.calls[spy.mock.calls.length - 1];
+    expect(additionalArguments).toEqual(
+      expect.arrayContaining(['--help', '--foo', 'bar']),
+    );
+    expect(additionalArguments).toHaveLength(3);
   });
 
   describe('swagger library', () => {

--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -46,6 +46,8 @@ export interface NormalizedSchema
   namespaceName: string;
   nxProjectName: string;
   projectType?: ProjectType;
+  args: string[];
+  __unparsed__: string[];
 }
 
 export async function normalizeOptions(
@@ -70,6 +72,8 @@ export async function normalizeOptions(
   const template = await getTemplate(options, client);
   const namespaceName = getNamespaceFromSchema(host, options, projectDirectory);
   const nxProjectName = names(options.name).fileName;
+  const __unparsed__ = options.__unparsed__ || [];
+  const args = options.args || [];
 
   return {
     ...options,
@@ -83,6 +87,8 @@ export async function normalizeOptions(
     projectTemplate: template as KnownDotnetTemplates,
     namespaceName,
     nxProjectName,
+    args,
+    __unparsed__,
     projectType: projectType ?? options.projectType ?? 'library',
   };
 }
@@ -209,11 +215,19 @@ export async function GenerateProject(
     output: normalizedOptions.projectRoot,
   };
 
+  const additionalArguments = normalizedOptions.args.concat(
+    normalizedOptions.__unparsed__,
+  );
+
   if (isDryRun()) {
     newParams['dryRun'] = true;
   }
 
-  dotnetClient.new(normalizedOptions.projectTemplate, newParams);
+  dotnetClient.new(
+    normalizedOptions.projectTemplate,
+    newParams,
+    additionalArguments,
+  );
   if (!isDryRun()) {
     addToSolutionFile(
       host,

--- a/packages/core/src/generators/utils/generate-test-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-test-project.spec.ts
@@ -93,6 +93,8 @@ describe('nx-dotnet test project generator', () => {
       namespaceName: 'Domain.ExistingApp',
       nxProjectName: 'domain-existing-app',
       pathScheme: 'nx',
+      args: [],
+      __unparsed__: [],
     };
     testProjectName = options.name + '-test';
   });

--- a/packages/core/src/models/project-generator-schema.ts
+++ b/packages/core/src/models/project-generator-schema.ts
@@ -16,4 +16,6 @@ export interface NxDotnetProjectGeneratorSchema {
   skipSwaggerLib: boolean;
   pathScheme: 'nx' | 'dotnet';
   useNxPluginOpenAPI?: boolean;
+  args?: string[];
+  __unparsed__?: string[];
 }

--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -27,12 +27,17 @@ import { LoadedCLI } from './dotnet.factory';
 export class DotNetClient {
   constructor(private cliCommand: LoadedCLI, public cwd?: string) {}
 
-  new(template: KnownDotnetTemplates, parameters?: dotnetNewOptions): void {
+  new(
+    template: KnownDotnetTemplates,
+    parameters?: dotnetNewOptions,
+    additionalArguments?: string[],
+  ): void {
     const params = [`new`, template];
     if (parameters) {
       parameters = swapKeysUsingMap(parameters, newKeyMap);
       params.push(...getSpawnParameterArray(parameters));
     }
+    params.push(...(additionalArguments || []));
     return this.logAndExecute(params);
   }
 


### PR DESCRIPTION
I've moved my version of this feature to its own PR.
This version is able to accept args passed after `--` using the additionalProperties feature from JSON-Schema.
Closes: #398 
Closes: #262