### PR TITLE
fix(core): support new name for enforce-module-boundaries eslint rule

### DIFF
--- a/packages/core/src/tasks/check-module-boundaries.spec.ts
+++ b/packages/core/src/tasks/check-module-boundaries.spec.ts
@@ -53,26 +53,29 @@ describe('load-module-boundaries', () => {
     expect(boundaries).toEqual(MOCK_BOUNDARIES);
   });
 
-  it('should load from eslint if boundaries not in config', async () => {
-    const eslintConfigSpy = jest
-      .spyOn(ESLintNamespace, 'ESLint')
-      .mockReturnValue({
-        calculateConfigForFile: jest.fn().mockResolvedValue({
-          rules: {
-            '@nrwl/nx/enforce-module-boundaries': [
-              1,
-              { depConstraints: MOCK_BOUNDARIES },
-            ],
-          },
-        }),
-      } as unknown as ESLintNamespace.ESLint);
-    writeJson<NxDotnetConfig>(appTree, CONFIG_FILE_PATH, {
-      nugetPackages: {},
-    });
-    const boundaries = await loadModuleBoundaries('', appTree);
-    expect(eslintConfigSpy).toHaveBeenCalledTimes(1);
-    expect(boundaries).toEqual(MOCK_BOUNDARIES);
-  });
+  it.each([
+    '@nrwl/nx/enforce-module-boundaries',
+    '@nx/enforce-module-boundaries',
+  ])(
+    'should load from eslint if boundaries not in config',
+    async (eslintRuleName) => {
+      const eslintConfigSpy = jest
+        .spyOn(ESLintNamespace, 'ESLint')
+        .mockReturnValue({
+          calculateConfigForFile: jest.fn().mockResolvedValue({
+            rules: {
+              [eslintRuleName]: [1, { depConstraints: MOCK_BOUNDARIES }],
+            },
+          }),
+        } as unknown as ESLintNamespace.ESLint);
+      writeJson<NxDotnetConfig>(appTree, CONFIG_FILE_PATH, {
+        nugetPackages: {},
+      });
+      const boundaries = await loadModuleBoundaries('', appTree);
+      expect(eslintConfigSpy).toHaveBeenCalledTimes(1);
+      expect(boundaries).toEqual(MOCK_BOUNDARIES);
+    },
+  );
 });
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -84,7 +87,7 @@ describe('enforce-module-boundaries', () => {
     jest.spyOn(ESLintNamespace, 'ESLint').mockReturnValue({
       calculateConfigForFile: jest.fn().mockResolvedValue({
         rules: {
-          '@nrwl/nx/enforce-module-boundaries': [
+          '@nx/enforce-module-boundaries': [
             1,
             { depConstraints: MOCK_BOUNDARIES },
           ],

--- a/packages/core/src/tasks/check-module-boundaries.ts
+++ b/packages/core/src/tasks/check-module-boundaries.ts
@@ -80,11 +80,13 @@ export async function loadModuleBoundaries(
         .calculateConfigForFile(`${root}/non-existant.ts`)
         .catch(() =>
           Promise.resolve({
-            rules: { '@nrwl/nx/enforce-module-boundaries': [] },
+            rules: { '@nx/enforce-module-boundaries': [] },
           }),
         );
       const [, moduleBoundaryConfig] =
-        result.rules['@nrwl/nx/enforce-module-boundaries'] || [];
+        result.rules['@nx/enforce-module-boundaries'] ||
+        result.rules['@nrwl/nx/enforce-module-boundaries'] ||
+        [];
       return moduleBoundaryConfig?.depConstraints ?? [];
     } catch {
       return [];


### PR DESCRIPTION
To fix the rescope that came in [v16 of nx](https://blog.nrwl.io/nx-16-is-here-69584ec87053#8e44).

Is backwards compatible with the old name, so no breaking changes/migrations needs.