### PR TITLE
feat(core): move generator now includes namespace

### DIFF
--- a/docs/core/generators/move.md
+++ b/docs/core/generators/move.md
@@ -2,7 +2,7 @@
 
 ## @nx-dotnet/core:move
 
-Moves {projectName} to {destination}. Renames the Nx project to match the new folder location. Additionally, updates any .csproj, .vbproj, .fsproj, or .sln files which pointed to the project.
+Moves {projectName} to {destination}. Renames the Nx and .NET project to match the destination. Additionally, updates all code references to the moved project.
 
 ## Options
 

--- a/packages/core/src/generators/move/generator.spec.ts
+++ b/packages/core/src/generators/move/generator.spec.ts
@@ -11,7 +11,7 @@ import {
 import { uniq } from '@nrwl/nx-plugin/testing';
 
 import generator from './generator';
-import { basename } from 'path';
+import { getNamespaceFromSchema } from '../utils/generate-project';
 
 describe('move generator', () => {
   let tree: Tree;
@@ -54,16 +54,14 @@ describe('move generator', () => {
     expect(tree.exists(`apps/test/readme.md`)).toBeFalsy();
   });
 
-  it('should update references in .csproj files', async () => {
-    const { project, root } = makeSimpleProject(tree, 'app', 'test');
-    const csProjPath = 'apps/other/Other.csproj';
+  it('should update project references in referencing .csproj files', async () => {
+    const { project, root, namespace } = makeSimpleProject(tree, 'app', 'test');
+    const otherCsProjPath = 'apps/other/Proj.Other.csproj';
     tree.write(
-      csProjPath,
+      otherCsProjPath,
       `<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
-      <ProjectReference Include="../test/${project}/${
-        names(project).className
-      }.csproj" />
+      <ProjectReference Include="../test/${project}/${namespace}.csproj" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -75,8 +73,8 @@ describe('move generator', () => {
   </Project>
   `,
     );
-    const destination = joinPathFragments(uniq('app'));
-    console.log(tree.read(csProjPath)?.toString());
+    const destination = uniq('app');
+    console.log(tree.read(otherCsProjPath)?.toString());
     await generator(tree, { projectName: project, destination });
     const config = readProjectConfiguration(
       tree,
@@ -85,10 +83,168 @@ describe('move generator', () => {
     expect(config).toBeDefined();
     expect(tree.exists(`apps/${destination}/readme.md`)).toBeTruthy();
     expect(tree.exists(`apps/test/readme.md`)).toBeFalsy();
-    const updatedCsProj = tree.read(csProjPath)?.toString();
+    const updatedCsProj = tree.read(otherCsProjPath)?.toString();
     expect(updatedCsProj).not.toContain(root);
     expect(updatedCsProj).not.toContain(project);
-    expect(updatedCsProj).toContain(basename(destination));
+    expect(updatedCsProj).toContain(destination);
+  });
+
+  it.each([
+    {
+      step: 'remain same level as sibling reference',
+      from: '',
+      to: '',
+      sourceReference: '../other/Proj.Other.csproj',
+      expectedReference: '../other/Proj.Other.csproj',
+    },
+    {
+      step: 'move down a level from sibling reference',
+      from: '',
+      to: 'nested',
+      sourceReference: '../other/Proj.Other.csproj',
+      expectedReference: '../../other/Proj.Other.csproj',
+    },
+    {
+      step: 'move up a level from sibling reference',
+      from: 'parent',
+      to: '',
+      sourceReference: '../other/Proj.Other.csproj',
+      expectedReference: '../parent/other/Proj.Other.csproj',
+    },
+  ])(
+    'should offset dependent projects in the moved project .csproj [$step]',
+    async ({ from, to, sourceReference, expectedReference }) => {
+      const { project, namespace, projectFilePath } = makeSimpleProject(
+        tree,
+        'app',
+        from,
+      );
+      tree.write(
+        projectFilePath,
+        `<Project Sdk="Microsoft.NET.Sdk">
+    <ItemGroup>
+      <ProjectReference Include="${sourceReference}" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <TargetFramework>net6.0</TargetFramework>
+      <RootNamespace>${namespace}</RootNamespace>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
+    </PropertyGroup>
+  </Project>
+  `,
+      );
+      console.log(tree.read(projectFilePath)?.toString());
+      const destination = joinPathFragments(to, uniq('app'));
+      await generator(tree, { projectName: project, destination });
+      const destinationNamespace = getNamespaceFromSchema(tree, destination);
+      const updatedCsProjPath = `apps/${destination}/${destinationNamespace}.csproj`;
+      const updatedCsProj = tree.read(updatedCsProjPath)?.toString();
+      expect(updatedCsProj).toContain(
+        `<RootNamespace>${destinationNamespace}</RootNamespace>`,
+      );
+      expect(updatedCsProj).toContain(`Include="${expectedReference}"`);
+    },
+  );
+
+  it('should rename project file', async () => {
+    const { project, projectFilePath } = makeSimpleProject(tree, 'lib', 'a/b');
+    tree.write(
+      projectFilePath,
+      '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><TargetFramework>netstandard2.0</TargetFramework></PropertyGroup></Project>',
+    );
+    const destinationProject = uniq('lib');
+    const destination = joinPathFragments('c', 'd', destinationProject);
+    await generator(tree, { projectName: project, destination });
+    expect(tree.exists(projectFilePath)).toBeFalsy();
+    const destinationNamespace = `Proj.C.D.${
+      names(destinationProject).className
+    }`;
+    expect(
+      tree.exists(`libs/${destination}/${destinationNamespace}.csproj`),
+    ).toBeTruthy();
+  });
+
+  it('should update namespace references in referencing project code files', async () => {
+    const {
+      project,
+      root,
+      namespace: sourceNamespace,
+    } = makeSimpleProject(tree, 'lib', 'a/b');
+    const classFilePath = joinPathFragments(root, 'Class.cs');
+    tree.write(
+      classFilePath,
+      `
+      namespace ${sourceNamespace}.Foo.Bar;
+      public class Class
+      {}`,
+    );
+    const dependentProjectFilePath = 'libs/other/Proj.Other.csproj';
+    tree.write(
+      dependentProjectFilePath,
+      `<Project Sdk="Microsoft.NET.Sdk">
+        <ItemGroup>
+          <ProjectReference Include="../a/b/${project}/${sourceNamespace}.csproj" />
+        </ItemGroup>
+      </Project>`,
+    );
+    const dependentClassFilePath = 'libs/other/Other.cs';
+    tree.write(
+      dependentClassFilePath,
+      `
+      namespace Other;
+      using ${sourceNamespace}.Foo.Bar;
+      public class OtherClass
+      {
+        System.Console.WriteLine(typeof(Class).FullName);
+        System.Console.WriteLine(typeof(${sourceNamespace}.Foo.Bar.Class).FullName);
+      }`,
+    );
+    const nonDependentClassFilePath = 'libs/other2/Other2.cs';
+    tree.write(
+      nonDependentClassFilePath,
+      `
+      namespace Other2;
+      using ${sourceNamespace}.From.Different.Assembly;
+      public class Other2Class
+      {
+        System.Console.WriteLine(typeof(${sourceNamespace}.From.Different.Assembly.Class).FullName);
+      }`,
+    );
+    const destinationProject = uniq('lib');
+    const destination = joinPathFragments('c', 'd', destinationProject);
+    const destinationNamespace = `Proj.C.D.${
+      names(destinationProject).className
+    }`;
+    await generator(tree, { projectName: project, destination });
+    const destinationRoot = `libs/c/d/${destinationProject}`;
+    const destinationClassFilePath = `${destinationRoot}/Class.cs`;
+    expect(tree.exists(destinationClassFilePath)).toBeTruthy();
+    const destinationClassFile = tree
+      .read(destinationClassFilePath)
+      ?.toString();
+    expect(destinationClassFile).not.toContain(
+      `namespace ${sourceNamespace}.Foo.Bar;`,
+    );
+    expect(destinationClassFile).toContain(
+      `namespace ${destinationNamespace}.Foo.Bar;`,
+    );
+    const dependentClassFile = tree.read(dependentClassFilePath)?.toString();
+    expect(dependentClassFile).not.toContain(
+      `using ${sourceNamespace}.Foo.Bar;`,
+    );
+    expect(dependentClassFile).toContain(
+      `using ${destinationNamespace}.Foo.Bar;`,
+    );
+    expect(dependentClassFile).toContain(
+      `typeof(${destinationNamespace}.Foo.Bar.Class)`,
+    );
+    const nonDependentClassFile = tree
+      .read(nonDependentClassFilePath)
+      ?.toString();
+    expect(nonDependentClassFile).toContain(sourceNamespace);
+    expect(nonDependentClassFile).not.toContain(destinationNamespace);
   });
 
   it('should update paths in project configuration', async () => {
@@ -111,7 +267,8 @@ describe('move generator', () => {
 
 function makeSimpleProject(tree: Tree, type: 'app' | 'lib', path?: string) {
   const project = uniq(type);
-  const root = joinPathFragments(`${type}s`, path ?? '', project);
+  const projectPath = joinPathFragments(path ?? '', project);
+  const root = joinPathFragments(`${type}s`, projectPath);
   addProjectConfiguration(tree, project, {
     root,
     sourceRoot: joinPathFragments(root, 'src'),
@@ -123,6 +280,9 @@ function makeSimpleProject(tree: Tree, type: 'app' | 'lib', path?: string) {
       },
     },
   });
+  const namespace = getNamespaceFromSchema(tree, projectPath);
+  const projectFilePath = joinPathFragments(root, `${namespace}.csproj`);
+  tree.write(projectFilePath, 'contents');
   tree.write(joinPathFragments(root, 'readme.md'), 'contents');
-  return { project, root };
+  return { project, root, namespace, projectFilePath };
 }

--- a/packages/core/src/generators/move/schema.json
+++ b/packages/core/src/generators/move/schema.json
@@ -3,7 +3,7 @@
   "cli": "nx",
   "$id": "Move",
   "title": "@nx-dotnet/core:move",
-  "description": "Moves {projectName} to {destination}. Renames the Nx project to match the new folder location. Additionally, updates any .csproj, .vbproj, .fsproj, or .sln files which pointed to the project.",
+  "description": "Moves {projectName} to {destination}. Renames the Nx and .NET project to match the destination. Additionally, updates all code references to the moved project.",
   "type": "object",
   "properties": {
     "projectName": {

--- a/packages/core/src/generators/utils/generate-project.ts
+++ b/packages/core/src/generators/utils/generate-project.ts
@@ -70,7 +70,7 @@ export async function normalizeOptions(
   );
   const parsedTags = getProjectTagsFromSchema(options);
   const template = await getTemplate(options, client);
-  const namespaceName = getNamespaceFromSchema(host, options, projectDirectory);
+  const namespaceName = getNamespaceFromSchema(host, projectDirectory);
   const nxProjectName = names(options.name).fileName;
   const __unparsed__ = options.__unparsed__ || [];
   const args = options.args || [];
@@ -99,9 +99,8 @@ function getNameFromSchema(options: NxDotnetProjectGeneratorSchema): string {
     : options.name;
 }
 
-function getNamespaceFromSchema(
+export function getNamespaceFromSchema(
   host: Tree,
-  options: NxDotnetProjectGeneratorSchema,
   projectDirectory: string,
 ): string {
   const { npmScope } = getWorkspaceLayout(host);


### PR DESCRIPTION
The app and lib generators derive the namespace from the project name.
For consistency, it makes sense to align the namespace in the move generator.

Cases:
1 - Update .NET project (.csproj) file name
2 - Update <RootNamespace> (if exists)
3 - Update namespace in all code files within moved project
4 - Update project reference path+filename in all referenced projects
5 - Update namespace in all referencing project code files 