### PR TITLE
feat(core): support allSourceTags (#768) and wildcards in check-module-boundaries.js

### DIFF
--- a/packages/utils/src/lib/models/nx.ts
+++ b/packages/utils/src/lib/models/nx.ts
@@ -1,6 +1,8 @@
-export type ModuleBoundaries = {
+export type ModuleBoundary = {
   sourceTag?: '*' | string;
   allSourceTags?: string[];
   onlyDependOnLibsWithTags?: string[];
   notDependOnLibsWithTags?: string[];
-}[];
+};
+
+export type ModuleBoundaries = ModuleBoundary[];

--- a/packages/utils/src/lib/models/nx.ts
+++ b/packages/utils/src/lib/models/nx.ts
@@ -1,5 +1,6 @@
 export type ModuleBoundaries = {
-  sourceTag: '*' | string;
+  sourceTag?: '*' | string;
+  allSourceTags?: string[];
   onlyDependOnLibsWithTags?: string[];
   notDependOnLibsWithTags?: string[];
 }[];


### PR DESCRIPTION
Addresses #768 

Also adds regex and glob matching - another feature of [@nx/eslint-plugin](https://nx.dev/core-features/enforce-module-boundaries#tag-formats)