### PR TITLE
fix(core): createDependencies should work on windows

### DIFF
--- a/packages/utils/src/lib/utility-functions/workspace.ts
+++ b/packages/utils/src/lib/utility-functions/workspace.ts
@@ -87,9 +87,8 @@ export function getDependenciesFromXmlFile(
   const found: RawProjectGraphDependency[] = [];
 
   const absoluteNetProjectFilePath = getAbsolutePath(filePath, workspaceRoot);
-  const netProjectFilePath = relative(
-    workspaceRoot,
-    absoluteNetProjectFilePath,
+  const netProjectFilePath = normalizePath(
+    relative(workspaceRoot, absoluteNetProjectFilePath),
   );
   const hostProjectDirectory = normalizePath(
     dirname(absoluteNetProjectFilePath),


### PR DESCRIPTION
The source file path should be normalized s.t. Nx can find it in the file map.