### PR TITLE
fix(core): options should be read correctly for project inference

### DIFF
--- a/packages/core/src/generators/import-projects/generator.ts
+++ b/packages/core/src/generators/import-projects/generator.ts
@@ -118,6 +118,7 @@ async function checkIfTestProject(host: Tree, path: string): Promise<boolean> {
   });
   return isTestProject;
 }
+
 function getDirectoriesWithProjectJson(host: Tree) {
   const nxProjects = getProjects(host);
   const collected: string[] = [];

--- a/packages/core/src/generators/nuget-reference/generator.ts
+++ b/packages/core/src/generators/nuget-reference/generator.ts
@@ -27,6 +27,7 @@ export default async function (
   const projectFilePath = await getProjectFileForNxProject(project);
 
   const config = readConfig(host);
+  config.nugetPackages ??= {};
   const configuredPkgVersion = config.nugetPackages[packageName];
   const resolvedVersion = await resolveVersionMismatch(
     options.version,

--- a/packages/core/src/generators/sync/generator.ts
+++ b/packages/core/src/generators/sync/generator.ts
@@ -15,6 +15,7 @@ import { updateDependencyVersions } from '../utils/update-dependency-version';
 
 export default async function (host: Tree) {
   const config = readConfig(host);
+  config.nugetPackages ??= {};
   const projects = await getNxDotnetProjects(host);
 
   for (const [projectName, configuration] of projects.entries()) {

--- a/packages/core/src/graph/create-nodes.ts
+++ b/packages/core/src/graph/create-nodes.ts
@@ -8,11 +8,7 @@ import {
 import { readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 
-import {
-  DefaultConfigValues,
-  NxDotnetConfig,
-  readConfig,
-} from '@nx-dotnet/utils';
+import { NxDotnetConfig, readConfig } from '@nx-dotnet/utils';
 
 import {
   GetBuildExecutorConfiguration,
@@ -76,9 +72,7 @@ export const createNodes: CreateNodesCompat<NxDotnetConfig> = [
     ctxOrOpts: CreateNodesContext | NxDotnetConfig | undefined,
     maybeCtx: CreateNodesContext | undefined,
   ) => {
-    const options: NxDotnetConfig =
-      ((maybeCtx ? ctxOrOpts : readConfig()) as NxDotnetConfig) ??
-      DefaultConfigValues;
+    const options: NxDotnetConfig = readConfig();
 
     if (!options.inferProjects) {
       return {};

--- a/packages/utils/src/lib/utility-functions/config.ts
+++ b/packages/utils/src/lib/utility-functions/config.ts
@@ -23,11 +23,11 @@ export const DefaultConfigValues: NxDotnetConfig = {
 export function readConfig(host?: Tree): NxDotnetConfig {
   const configFromFile = readConfigFromRCFile(host);
   const configFromNxJson = readConfigFromNxJson(host);
-  return {
-    ...DefaultConfigValues,
-    ...configFromFile,
-    ...configFromNxJson,
-  };
+  return mergeConfigValues(
+    DefaultConfigValues,
+    configFromFile,
+    configFromNxJson,
+  );
 }
 
 export function updateConfig(host: Tree, value: NxDotnetConfig) {
@@ -111,4 +111,16 @@ export function readConfigFromNxJson(host?: Tree): NxDotnetConfig | null {
   } catch {
     return null;
   }
+}
+
+export function mergeConfigValues(
+  ...configs: (Partial<NxDotnetConfig> | null)[]
+): NxDotnetConfig {
+  return configs.reduce(
+    (acc, config) => ({
+      ...acc,
+      ...config,
+    }),
+    DefaultConfigValues,
+  ) as NxDotnetConfig;
 }


### PR DESCRIPTION
There's an issue with how we read configuration in Nx 17. It results in default values not being applied for some options, and project inference not working after migration.

This updates config handling to merge all values rather than relying on nullish handling.