### PR TITLE
fix(dotnet): correct flag passed to client to verify no changes

### DIFF
--- a/packages/dotnet/src/lib/core/dotnet.client.spec.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.spec.ts
@@ -285,6 +285,38 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
       `);
     });
 
+    it('should call subcommands properly when on .NET 6 and passing --fixWhitespace and --check', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.format('my-project', {
+        fixWhitespace: false,
+        check: true,
+      });
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        [
+          [
+            [
+              "format",
+              "style",
+              "my-project",
+              "--verify-no-changes",
+            ],
+          ],
+          [
+            [
+              "format",
+              "analyzers",
+              "my-project",
+              "--verify-no-changes",
+            ],
+          ],
+        ]
+      `);
+    });
+
     it('should call subcommands properly when on .NET 6 and passing --fixAnalyzers severity', () => {
       const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
       const spy = jest

--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -215,9 +215,10 @@ export class DotNetClient {
         const subcommandParameterObject = {
           ...parameters,
         };
-        delete subcommandParameterObject.fixWhitespace;
         subcommandParams.push(
-          ...getSpawnParameterArray(subcommandParameterObject),
+          ...getSpawnParameterArray(
+            swapKeysUsingMap(subcommandParameterObject, formatKeyMap),
+          ),
         );
         this.logAndExecute(subcommandParams);
       }
@@ -231,9 +232,10 @@ export class DotNetClient {
         if (typeof style === 'string') {
           subcommandParameterObject.severity = style;
         }
-        delete subcommandParameterObject.fixStyle;
         subcommandParams.push(
-          ...getSpawnParameterArray(subcommandParameterObject),
+          ...getSpawnParameterArray(
+            swapKeysUsingMap(subcommandParameterObject, formatKeyMap),
+          ),
         );
         this.logAndExecute(subcommandParams);
       }
@@ -247,17 +249,19 @@ export class DotNetClient {
         if (typeof analyzers === 'string') {
           subcommandParameterObject.severity = analyzers;
         }
-        delete subcommandParameterObject.fixAnalyzers;
         subcommandParams.push(
-          ...getSpawnParameterArray(subcommandParameterObject),
+          ...getSpawnParameterArray(
+            swapKeysUsingMap(subcommandParameterObject, formatKeyMap),
+          ),
         );
         this.logAndExecute(subcommandParams);
       }
     } else {
       params.push(project);
       if (parameters) {
-        parameters = swapKeysUsingMap(parameters, formatKeyMap);
-        params.push(...getSpawnParameterArray(parameters));
+        params.push(
+          ...getSpawnParameterArray(swapKeysUsingMap(parameters, formatKeyMap)),
+        );
       }
       return this.logAndExecute(params);
     }


### PR DESCRIPTION
When using the new .net 6 format flags, it would pass `--verifyNoChanges` instead of `---verify-no-changes`, which would not work.
This fixes that by passing the args for the new commands through the normal swap keys function.
