### PR TITLE
fix(dotnet): prevent "false" being incorrectly passed to dotnet command

### DIFF
--- a/packages/dotnet/src/lib/core/dotnet.client.spec.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.spec.ts
@@ -484,4 +484,50 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
       `);
     });
   });
+
+  describe('test', () => {
+    it('should call test command', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.test('my-project', false, {
+        blame: false,
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        [
+          [
+            [
+              "test",
+              "my-project",
+            ],
+          ],
+        ]
+      `);
+    });
+  });
+
+  describe('build', () => {
+    it('should call build command', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
+      const spy = jest
+        .spyOn(dotnetClient, 'logAndExecute')
+        .mockImplementation(() => ({}));
+      dotnetClient.build('my-project', {
+        noDependencies: false,
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        [
+          [
+            [
+              "build",
+              "my-project",
+            ],
+          ],
+        ]
+      `);
+    });
+  });
 });

--- a/packages/dotnet/src/lib/core/dotnet.client.spec.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.spec.ts
@@ -4,6 +4,10 @@ import { DotNetClient } from './dotnet.client';
 import { dotnetFactory, mockDotnetFactory } from './dotnet.factory';
 
 describe('dotnet client', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   describe('publish', () => {
     describe('extra parameters', () => {
       const dotnetClient = new DotNetClient(mockDotnetFactory());
@@ -13,13 +17,7 @@ describe('dotnet client', () => {
       beforeEach(() => {
         spawnSyncSpy = jest
           .spyOn(cp, 'spawnSync')
-          .mockReturnValue({ status: 0 } as Partial<
-            cp.SpawnSyncReturns<Buffer>
-          > as cp.SpawnSyncReturns<Buffer>);
-      });
-
-      afterEach(() => {
-        jest.resetAllMocks();
+          .mockReturnValue({ status: 0 } as cp.SpawnSyncReturns<Buffer>);
       });
 
       it('should handle multiple parameters', () => {
@@ -77,6 +75,27 @@ describe('dotnet client', () => {
         );
         expect(spawnSyncSpy.mock.calls[0][1]).toContain('-p:Name=bar');
       });
+    });
+    it('should convert options to flags', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory());
+      const spawnSyncSpy = jest
+        .spyOn(cp, 'spawnSync')
+        .mockReturnValue({ status: 0 } as cp.SpawnSyncReturns<Buffer>);
+      dotnetClient.publish('my-project', {
+        noBuild: false,
+        noRestore: true,
+        configuration: 'Release',
+      });
+      expect(spawnSyncSpy).toBeCalledTimes(1);
+      expect(spawnSyncSpy.mock.calls[0][1]).toMatchInlineSnapshot(`
+        [
+          "publish",
+          ""my-project"",
+          "--no-restore",
+          "--configuration",
+          "Release",
+        ]
+      `);
     });
   });
 
@@ -486,46 +505,124 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
   });
 
   describe('test', () => {
-    it('should call test command', () => {
-      const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
-      const spy = jest
-        .spyOn(dotnetClient, 'logAndExecute')
-        .mockImplementation(() => ({}));
+    it('should convert options to flags', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory());
+      const spawnSyncSpy = jest
+        .spyOn(cp, 'spawnSync')
+        .mockReturnValue({ status: 0 } as cp.SpawnSyncReturns<Buffer>);
       dotnetClient.test('my-project', false, {
         blame: false,
+        noRestore: true,
+        blameHang: true,
+        blameHangDump: 'dump.file',
       });
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy.mock.calls).toMatchInlineSnapshot(`
+      expect(spawnSyncSpy).toHaveBeenCalledTimes(1);
+      expect(spawnSyncSpy.mock.calls[0][1]).toMatchInlineSnapshot(`
         [
-          [
-            [
-              "test",
-              "my-project",
-            ],
-          ],
+          "test",
+          "my-project",
+          "--no-restore",
+          "--blame-hang",
+          "--blame-hang-dump",
+          "dump.file",
         ]
       `);
     });
   });
 
   describe('build', () => {
-    it('should call build command', () => {
-      const dotnetClient = new DotNetClient(mockDotnetFactory('6.0.0'));
-      const spy = jest
-        .spyOn(dotnetClient, 'logAndExecute')
-        .mockImplementation(() => ({}));
+    it('should convert options to flags', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory());
+      const spawnSyncSpy = jest
+        .spyOn(cp, 'spawnSync')
+        .mockReturnValue({ status: 0 } as cp.SpawnSyncReturns<Buffer>);
       dotnetClient.build('my-project', {
         noDependencies: false,
+        noRestore: true,
+        configuration: 'Release',
       });
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy.mock.calls).toMatchInlineSnapshot(`
+      expect(spawnSyncSpy).toHaveBeenCalledTimes(1);
+      expect(spawnSyncSpy.mock.calls[0][1]).toMatchInlineSnapshot(`
         [
-          [
-            [
-              "build",
-              "my-project",
-            ],
-          ],
+          "build",
+          "my-project",
+          "--no-restore",
+          "--configuration",
+          "Release",
+        ]
+      `);
+    });
+  });
+
+  describe('addPackageReference', () => {
+    it('should convert options to flags', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory());
+      const spawnSyncSpy = jest
+        .spyOn(cp, 'spawnSync')
+        .mockReturnValue({ status: 0 } as cp.SpawnSyncReturns<Buffer>);
+      dotnetClient.addPackageReference('my-project', 'other-package', {
+        noRestore: true,
+        version: '1.2.3',
+      });
+      expect(spawnSyncSpy).toHaveBeenCalledTimes(1);
+      expect(spawnSyncSpy.mock.calls[0][1]).toMatchInlineSnapshot(`
+        [
+          "add",
+          "my-project",
+          "package",
+          "other-package",
+          "--no-restore",
+          "--version",
+          "1.2.3",
+        ]
+      `);
+    });
+  });
+
+  describe('new', () => {
+    it('should convert options to flags', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory());
+      const spawnSyncSpy = jest
+        .spyOn(cp, 'spawnSync')
+        .mockReturnValue({ status: 0 } as cp.SpawnSyncReturns<Buffer>);
+      dotnetClient.new('my-template', {
+        dryRun: true,
+        force: false,
+        name: 'my-project',
+      });
+      expect(spawnSyncSpy).toHaveBeenCalledTimes(1);
+      expect(spawnSyncSpy.mock.calls[0][1]).toMatchInlineSnapshot(`
+        [
+          "new",
+          "my-template",
+          "--dry-run",
+          "--name",
+          "my-project",
+        ]
+      `);
+    });
+  });
+
+  describe('run', () => {
+    it('should convert options to flags', () => {
+      const dotnetClient = new DotNetClient(mockDotnetFactory());
+      const spawnSpy = jest
+        .spyOn(cp, 'spawn')
+        .mockReturnValue({ exitCode: 0 } as cp.ChildProcess);
+      dotnetClient.run('my-project', false, {
+        noRestore: true,
+        noDependencies: false,
+        configuration: 'Release',
+      });
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      expect(spawnSpy.mock.calls[0][1]).toMatchInlineSnapshot(`
+        [
+          "run",
+          "--project",
+          "my-project",
+          "--no-restore",
+          "--configuration",
+          "Release",
         ]
       `);
     });

--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -1,7 +1,11 @@
 import { ChildProcess, spawn, spawnSync } from 'child_process';
 import * as semver from 'semver';
 
-import { getSpawnParameterArray, swapKeysUsingMap } from '@nx-dotnet/utils';
+import {
+  getSpawnParameterArray,
+  swapExplicitFalseKeys,
+  swapKeysUsingMap,
+} from '@nx-dotnet/utils';
 
 import {
   addPackageKeyMap,
@@ -14,6 +18,7 @@ import {
   dotnetRunOptions,
   DotnetTemplate,
   dotnetTestOptions,
+  formatExplicitFalseFlags,
   formatKeyMap,
   KnownDotnetTemplates,
   newKeyMap,
@@ -260,7 +265,12 @@ export class DotNetClient {
       params.push(project);
       if (parameters) {
         params.push(
-          ...getSpawnParameterArray(swapKeysUsingMap(parameters, formatKeyMap)),
+          ...getSpawnParameterArray(
+            swapKeysUsingMap(
+              swapExplicitFalseKeys(parameters, formatExplicitFalseFlags),
+              formatKeyMap,
+            ),
+          ),
         );
       }
       return this.logAndExecute(params);

--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -2,14 +2,13 @@ import { ChildProcess, spawn, spawnSync } from 'child_process';
 import * as semver from 'semver';
 
 import {
+  convertOptionsToParams,
   getSpawnParameterArray,
-  swapExplicitFalseKeys,
-  swapKeysUsingMap,
 } from '@nx-dotnet/utils';
 
 import {
-  addPackageKeyMap,
-  buildKeyMap,
+  addPackageCommandLineParamFixes,
+  buildCommandLineParamFixes,
   dotnetAddPackageOptions,
   dotnetBuildOptions,
   dotnetFormatOptions,
@@ -18,19 +17,21 @@ import {
   dotnetRunOptions,
   DotnetTemplate,
   dotnetTestOptions,
-  formatExplicitFalseFlags,
-  formatKeyMap,
+  formatCommandLineParamFixes,
   KnownDotnetTemplates,
-  newKeyMap,
-  publishKeyMap,
-  runKeyMap,
-  testKeyMap,
+  newCommandLineParamFixes,
+  publishCommandLineParamFixes,
+  runCommandLineParamFixes,
+  testCommandLineParamFixes,
 } from '../models';
 import { parseDotnetNewListOutput } from '../utils/parse-dotnet-new-list-output';
 import { LoadedCLI } from './dotnet.factory';
 
 export class DotNetClient {
-  constructor(private cliCommand: LoadedCLI, public cwd?: string) {}
+  constructor(
+    private cliCommand: LoadedCLI,
+    public cwd?: string,
+  ) {}
 
   new(
     template: KnownDotnetTemplates,
@@ -39,8 +40,9 @@ export class DotNetClient {
   ): void {
     const params = [`new`, template];
     if (parameters) {
-      parameters = swapKeysUsingMap(parameters, newKeyMap);
-      params.push(...getSpawnParameterArray(parameters));
+      params.push(
+        ...convertOptionsToParams(parameters, newCommandLineParamFixes),
+      );
     }
     params.push(...(additionalArguments ?? []));
     return this.logAndExecute(params);
@@ -77,8 +79,9 @@ export class DotNetClient {
   ): void {
     const params = [`build`, project];
     if (parameters) {
-      parameters = swapKeysUsingMap(parameters, buildKeyMap);
-      params.push(...getSpawnParameterArray(parameters));
+      params.push(
+        ...convertOptionsToParams(parameters, buildCommandLineParamFixes),
+      );
     }
     if (extraParameters) {
       const matches = extraParameters.match(EXTRA_PARAMS_REGEX);
@@ -96,8 +99,9 @@ export class DotNetClient {
       ? [`watch`, `--project`, project, `run`]
       : [`run`, `--project`, project];
     if (parameters) {
-      parameters = swapKeysUsingMap(parameters, runKeyMap);
-      params.push(...getSpawnParameterArray(parameters));
+      params.push(
+        ...convertOptionsToParams(parameters, runCommandLineParamFixes),
+      );
     }
 
     return this.logAndSpawn(params);
@@ -114,8 +118,9 @@ export class DotNetClient {
       : [`test`, project];
 
     if (parameters) {
-      parameters = swapKeysUsingMap(parameters, testKeyMap);
-      params.push(...getSpawnParameterArray(parameters));
+      params.push(
+        ...convertOptionsToParams(parameters, testCommandLineParamFixes),
+      );
     }
     if (extraParameters) {
       const matches = extraParameters.match(EXTRA_PARAMS_REGEX);
@@ -135,8 +140,9 @@ export class DotNetClient {
   ): void {
     const params = [`add`, project, `package`, pkg];
     if (parameters) {
-      parameters = swapKeysUsingMap(parameters, addPackageKeyMap);
-      params.push(...getSpawnParameterArray(parameters));
+      params.push(
+        ...convertOptionsToParams(parameters, addPackageCommandLineParamFixes),
+      );
     }
     return this.logAndExecute(params);
   }
@@ -153,8 +159,9 @@ export class DotNetClient {
   ): void {
     const params = [`publish`, `"${project}"`];
     if (parameters) {
-      parameters = swapKeysUsingMap(parameters, publishKeyMap);
-      params.push(...getSpawnParameterArray(parameters));
+      params.push(
+        ...convertOptionsToParams(parameters, publishCommandLineParamFixes),
+      );
     }
     if (publishProfile) {
       params.push(`-p:PublishProfile=${publishProfile}`);
@@ -221,8 +228,9 @@ export class DotNetClient {
           ...parameters,
         };
         subcommandParams.push(
-          ...getSpawnParameterArray(
-            swapKeysUsingMap(subcommandParameterObject, formatKeyMap),
+          ...convertOptionsToParams(
+            subcommandParameterObject,
+            formatCommandLineParamFixes,
           ),
         );
         this.logAndExecute(subcommandParams);
@@ -238,8 +246,9 @@ export class DotNetClient {
           subcommandParameterObject.severity = style;
         }
         subcommandParams.push(
-          ...getSpawnParameterArray(
-            swapKeysUsingMap(subcommandParameterObject, formatKeyMap),
+          ...convertOptionsToParams(
+            subcommandParameterObject,
+            formatCommandLineParamFixes,
           ),
         );
         this.logAndExecute(subcommandParams);
@@ -255,8 +264,9 @@ export class DotNetClient {
           subcommandParameterObject.severity = analyzers;
         }
         subcommandParams.push(
-          ...getSpawnParameterArray(
-            swapKeysUsingMap(subcommandParameterObject, formatKeyMap),
+          ...convertOptionsToParams(
+            subcommandParameterObject,
+            formatCommandLineParamFixes,
           ),
         );
         this.logAndExecute(subcommandParams);
@@ -265,12 +275,7 @@ export class DotNetClient {
       params.push(project);
       if (parameters) {
         params.push(
-          ...getSpawnParameterArray(
-            swapKeysUsingMap(
-              swapExplicitFalseKeys(parameters, formatExplicitFalseFlags),
-              formatKeyMap,
-            ),
-          ),
+          ...convertOptionsToParams(parameters, formatCommandLineParamFixes),
         );
       }
       return this.logAndExecute(params);

--- a/packages/dotnet/src/lib/models/dotnet-add-package/dotnet-add-package-flags.ts
+++ b/packages/dotnet/src/lib/models/dotnet-add-package/dotnet-add-package-flags.ts
@@ -1,3 +1,5 @@
+import { CommandLineParamFixes } from '@nx-dotnet/utils';
+
 export type dotnetAddPackageFlags =
   | 'version'
   | 'framework'
@@ -6,9 +8,11 @@ export type dotnetAddPackageFlags =
   | 'noRestore'
   | 'source';
 
-export const addPackageKeyMap: Partial<{
-  [key in dotnetAddPackageFlags]: string;
-}> = {
-  packageDirectory: 'package-directory',
-  noRestore: 'no-restore',
-};
+export const addPackageCommandLineParamFixes: CommandLineParamFixes<dotnetAddPackageFlags> =
+  {
+    keyMap: {
+      packageDirectory: 'package-directory',
+      noRestore: 'no-restore',
+    },
+    explicitFalseKeys: [],
+  };

--- a/packages/dotnet/src/lib/models/dotnet-build/dotnet-build-flags.ts
+++ b/packages/dotnet/src/lib/models/dotnet-build/dotnet-build-flags.ts
@@ -1,3 +1,5 @@
+import { CommandLineParamFixes } from '@nx-dotnet/utils';
+
 export type dotnetBuildFlags =
   | 'configuration'
   | 'framework'
@@ -12,9 +14,13 @@ export type dotnetBuildFlags =
   | 'versionSuffix'
   | 'runtime';
 
-export const buildKeyMap: Partial<{ [key in dotnetBuildFlags]: string }> = {
-  noRestore: 'no-restore',
-  noIncremental: 'no-incremental',
-  noDependencies: 'no-dependencies',
-  versionSuffix: 'version-suffix',
-};
+export const buildCommandLineParamFixes: CommandLineParamFixes<dotnetBuildFlags> =
+  {
+    keyMap: {
+      noRestore: 'no-restore',
+      noIncremental: 'no-incremental',
+      noDependencies: 'no-dependencies',
+      versionSuffix: 'version-suffix',
+    },
+    explicitFalseKeys: [],
+  };

--- a/packages/dotnet/src/lib/models/dotnet-format/dotnet-format-flags.ts
+++ b/packages/dotnet/src/lib/models/dotnet-format/dotnet-format-flags.ts
@@ -21,3 +21,9 @@ export const formatKeyMap: Partial<{ [key in dotnetFormatFlags]: string }> = {
   fixAnalyzers: 'fix-analyzers',
   verifyNoChanges: 'verify-no-changes',
 };
+
+export const formatExplicitFalseFlags: readonly dotnetFormatFlags[] = [
+  'fixAnalyzers',
+  'fixStyle',
+  'fixWhitespace',
+];

--- a/packages/dotnet/src/lib/models/dotnet-format/dotnet-format-flags.ts
+++ b/packages/dotnet/src/lib/models/dotnet-format/dotnet-format-flags.ts
@@ -1,3 +1,5 @@
+import { CommandLineParamFixes } from '@nx-dotnet/utils';
+
 export type dotnetFormatFlags =
   | 'noRestore'
   // Deliberately excluding the folder option, as the csproj file is always used as the workspace.
@@ -14,16 +16,14 @@ export type dotnetFormatFlags =
   | 'verifyNoChanges';
 // Deliberately excluding the version option, as it doesn't perform any actual formatting.
 
-export const formatKeyMap: Partial<{ [key in dotnetFormatFlags]: string }> = {
-  noRestore: 'no-restore',
-  fixWhitespace: 'fix-whitespace',
-  fixStyle: 'fix-style',
-  fixAnalyzers: 'fix-analyzers',
-  verifyNoChanges: 'verify-no-changes',
-};
-
-export const formatExplicitFalseFlags: readonly dotnetFormatFlags[] = [
-  'fixAnalyzers',
-  'fixStyle',
-  'fixWhitespace',
-];
+export const formatCommandLineParamFixes: CommandLineParamFixes<dotnetFormatFlags> =
+  {
+    keyMap: {
+      noRestore: 'no-restore',
+      fixWhitespace: 'fix-whitespace',
+      fixStyle: 'fix-style',
+      fixAnalyzers: 'fix-analyzers',
+      verifyNoChanges: 'verify-no-changes',
+    },
+    explicitFalseKeys: ['fixWhitespace', 'fixStyle', 'fixAnalyzers'],
+  };

--- a/packages/dotnet/src/lib/models/dotnet-new/dotnet-new-flags.ts
+++ b/packages/dotnet/src/lib/models/dotnet-new/dotnet-new-flags.ts
@@ -1,3 +1,5 @@
+import { CommandLineParamFixes } from '@nx-dotnet/utils';
+
 export type dotnetNewFlags =
   | 'dryRun'
   | 'force'
@@ -10,9 +12,12 @@ export type dotnetNewFlags =
   | 'updateApply'
   | 'updateCheck';
 
-export const newKeyMap: Partial<{ [key in dotnetNewFlags]: string }> = {
-  dryRun: 'dry-run',
-  updateApply: 'update-apply',
-  updateCheck: 'update-check',
-  nugetSource: 'nuget-source',
+export const newCommandLineParamFixes: CommandLineParamFixes<dotnetNewFlags> = {
+  keyMap: {
+    dryRun: 'dry-run',
+    updateApply: 'update-apply',
+    updateCheck: 'update-check',
+    nugetSource: 'nuget-source',
+  },
+  explicitFalseKeys: [],
 };

--- a/packages/dotnet/src/lib/models/dotnet-publish/dotnet-publish-flags.ts
+++ b/packages/dotnet/src/lib/models/dotnet-publish/dotnet-publish-flags.ts
@@ -1,3 +1,5 @@
+import { CommandLineParamFixes } from '@nx-dotnet/utils';
+
 export type dotnetPublishFlags =
   | 'configuration'
   | 'framework'
@@ -13,10 +15,14 @@ export type dotnetPublishFlags =
   | 'verbosity'
   | 'versionSuffix';
 
-export const publishKeyMap: Partial<{ [key in dotnetPublishFlags]: string }> = {
-  noBuild: 'no-build',
-  noDependencies: 'no-dependencies',
-  noRestore: 'no-restore',
-  selfContained: 'self-contained',
-  versionSuffix: 'version-suffix',
-};
+export const publishCommandLineParamFixes: CommandLineParamFixes<dotnetPublishFlags> =
+  {
+    keyMap: {
+      noBuild: 'no-build',
+      noDependencies: 'no-dependencies',
+      noRestore: 'no-restore',
+      selfContained: 'self-contained',
+      versionSuffix: 'version-suffix',
+    },
+    explicitFalseKeys: [],
+  };

--- a/packages/dotnet/src/lib/models/dotnet-run/dotnet-run-flags.ts
+++ b/packages/dotnet/src/lib/models/dotnet-run/dotnet-run-flags.ts
@@ -1,3 +1,5 @@
+import { CommandLineParamFixes } from '@nx-dotnet/utils';
+
 export type dotnetRunFlags =
   | 'configuration'
   | 'framework'
@@ -12,9 +14,12 @@ export type dotnetRunFlags =
   | 'versionSuffix'
   | 'runtime';
 
-export const runKeyMap: Partial<{ [key in dotnetRunFlags]: string }> = {
-  noDependencies: 'no-dependencies',
-  noRestore: 'no-restore',
-  versionSuffix: 'version-suffix',
-  noIncremental: 'no-incremental',
+export const runCommandLineParamFixes: CommandLineParamFixes<dotnetRunFlags> = {
+  keyMap: {
+    noDependencies: 'no-dependencies',
+    noRestore: 'no-restore',
+    versionSuffix: 'version-suffix',
+    noIncremental: 'no-incremental',
+  },
+  explicitFalseKeys: [],
 };

--- a/packages/dotnet/src/lib/models/dotnet-test/dotnet-test-flags.ts
+++ b/packages/dotnet/src/lib/models/dotnet-test/dotnet-test-flags.ts
@@ -1,3 +1,5 @@
+import { CommandLineParamFixes } from '@nx-dotnet/utils';
+
 export type dotnetTestFlags =
   | 'blameCrashCollectAlways'
   | 'blameCrashDumpType'
@@ -21,16 +23,20 @@ export type dotnetTestFlags =
   | 'testAdapterPath'
   | 'verbosity';
 
-export const testKeyMap: Partial<{ [key in dotnetTestFlags]: string }> = {
-  blameCrashCollectAlways: 'blame-crash-collect-always',
-  blameCrash: 'blame-crash',
-  blameCrashDumpType: 'blame-crash-dump-type',
-  blameHangDump: 'blame-hang-dump',
-  blameHang: 'blame-hang',
-  blameHangTimeout: 'blame-hang-timeout',
-  listTests: 'list-tests',
-  noBuild: 'no-build',
-  noRestore: 'no-restore',
-  resultsDirectory: 'results-directory',
-  testAdapterPath: 'test-adapter-path',
-};
+export const testCommandLineParamFixes: CommandLineParamFixes<dotnetTestFlags> =
+  {
+    keyMap: {
+      blameCrashCollectAlways: 'blame-crash-collect-always',
+      blameCrash: 'blame-crash',
+      blameCrashDumpType: 'blame-crash-dump-type',
+      blameHangDump: 'blame-hang-dump',
+      blameHang: 'blame-hang',
+      blameHangTimeout: 'blame-hang-timeout',
+      listTests: 'list-tests',
+      noBuild: 'no-build',
+      noRestore: 'no-restore',
+      resultsDirectory: 'results-directory',
+      testAdapterPath: 'test-adapter-path',
+    },
+    explicitFalseKeys: [],
+  };

--- a/packages/utils/src/lib/utility-functions/args.spec.ts
+++ b/packages/utils/src/lib/utility-functions/args.spec.ts
@@ -1,4 +1,4 @@
-import { isDryRun, swapExplicitFalseKeys } from './args';
+import { isDryRun } from './args';
 
 describe('Args util functions', () => {
   describe('isDryRun', () => {
@@ -7,28 +7,6 @@ describe('Args util functions', () => {
       process.argv.push('--dry-run');
       const after = isDryRun();
       expect({ before, after }).toStrictEqual({ before: false, after: true });
-    });
-  });
-
-  describe('swapExplicitFalseKeys', () => {
-    it('should change a value to the string "false" if in the explicit false list', () => {
-      const result = swapExplicitFalseKeys(
-        {
-          fixWhitespace: false,
-          fixStyle: true,
-          fixAnalyzers: false,
-          noBuild: false,
-          noDependencies: true,
-        },
-        ['fixWhitespace', 'fixStyle', 'fixAnalyzers'],
-      );
-      expect(result).toStrictEqual({
-        fixWhitespace: 'false',
-        fixStyle: true,
-        fixAnalyzers: 'false',
-        noBuild: false,
-        noDependencies: true,
-      });
     });
   });
 });

--- a/packages/utils/src/lib/utility-functions/args.spec.ts
+++ b/packages/utils/src/lib/utility-functions/args.spec.ts
@@ -1,4 +1,4 @@
-import { isDryRun } from './args';
+import { isDryRun, swapExplicitFalseKeys } from './args';
 
 describe('Args util functions', () => {
   describe('isDryRun', () => {
@@ -7,6 +7,28 @@ describe('Args util functions', () => {
       process.argv.push('--dry-run');
       const after = isDryRun();
       expect({ before, after }).toStrictEqual({ before: false, after: true });
+    });
+  });
+
+  describe('swapExplicitFalseKeys', () => {
+    it('should change a value to the string "false" if in the explicit false list', () => {
+      const result = swapExplicitFalseKeys(
+        {
+          fixWhitespace: false,
+          fixStyle: true,
+          fixAnalyzers: false,
+          noBuild: false,
+          noDependencies: true,
+        },
+        ['fixWhitespace', 'fixStyle', 'fixAnalyzers'],
+      );
+      expect(result).toStrictEqual({
+        fixWhitespace: 'false',
+        fixStyle: true,
+        fixAnalyzers: 'false',
+        noBuild: false,
+        noDependencies: true,
+      });
     });
   });
 });

--- a/packages/utils/src/lib/utility-functions/args.ts
+++ b/packages/utils/src/lib/utility-functions/args.ts
@@ -13,3 +13,17 @@ export function swapKeysUsingMap(
     ]),
   );
 }
+
+export function swapExplicitFalseKeys<
+  TRecord extends Record<string, string | boolean>,
+>(
+  object: TRecord,
+  explicitFalseKeys: readonly (keyof TRecord)[],
+): Record<string, string | boolean> {
+  return Object.fromEntries(
+    Object.entries(object).map(([key, value]) => [
+      key,
+      explicitFalseKeys.includes(key) && value === false ? 'false' : value,
+    ]),
+  ) as Record<string, string | boolean>;
+}

--- a/packages/utils/src/lib/utility-functions/args.ts
+++ b/packages/utils/src/lib/utility-functions/args.ts
@@ -1,29 +1,3 @@
 export function isDryRun(): boolean {
   return process.argv.some((x) => x === '--dry-run');
 }
-
-export function swapKeysUsingMap(
-  object: Record<string, string | boolean>,
-  map: Record<string, string>,
-): Record<string, string | boolean> {
-  return Object.fromEntries(
-    Object.entries(object).map(([key, value]) => [
-      key in map ? map[key] : key,
-      value,
-    ]),
-  );
-}
-
-export function swapExplicitFalseKeys<
-  TRecord extends Record<string, string | boolean>,
->(
-  object: TRecord,
-  explicitFalseKeys: readonly (keyof TRecord)[],
-): Record<string, string | boolean> {
-  return Object.fromEntries(
-    Object.entries(object).map(([key, value]) => [
-      key,
-      explicitFalseKeys.includes(key) && value === false ? 'false' : value,
-    ]),
-  ) as Record<string, string | boolean>;
-}

--- a/packages/utils/src/lib/utility-functions/parameters.spec.ts
+++ b/packages/utils/src/lib/utility-functions/parameters.spec.ts
@@ -1,0 +1,51 @@
+import { convertOptionsToParams } from './parameters';
+
+describe('convertOptionsToParams', () => {
+  it('should change a value to the string "false" if in the explicit false list', () => {
+    const options = {
+      fixWhitespace: false,
+      fixStyle: true,
+      fixAnalyzers: false,
+      noBuild: false,
+      noDependencies: true,
+    } as const;
+    const result = convertOptionsToParams(options, {
+      explicitFalseKeys: ['fixWhitespace', 'fixStyle', 'fixAnalyzers'],
+      keyMap: {},
+    });
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "--fixWhitespace",
+        "false",
+        "--fixStyle",
+        "--fixAnalyzers",
+        "false",
+        "--noDependencies",
+      ]
+    `);
+  });
+
+  it('should map a key in the key map', () => {
+    const options = {
+      fixWhitespace: false,
+      fixStyle: true,
+      fixAnalyzers: false,
+      noBuild: false,
+      noDependencies: true,
+    } as const;
+    const result = convertOptionsToParams(options, {
+      explicitFalseKeys: [],
+      keyMap: {
+        fixWhitespace: 'fix-whitespace',
+        fixStyle: 'fix-style',
+        fixAnalyzers: 'fix-analyzers',
+      },
+    });
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "--fix-style",
+        "--noDependencies",
+      ]
+    `);
+  });
+});

--- a/packages/utils/src/lib/utility-functions/parameters.ts
+++ b/packages/utils/src/lib/utility-functions/parameters.ts
@@ -25,7 +25,7 @@ export function getParameterString(
  * @returns Parameter string to be appended to CLI command
  */
 export function getSpawnParameterArray(
-  parameters: Record<string, boolean | string>,
+  parameters: Record<string, boolean | string | number | undefined | null>,
 ): string[] {
   const spawnArray: string[] = [];
   for (const [key, value] of Object.entries(parameters)) {
@@ -38,4 +38,36 @@ export function getSpawnParameterArray(
     }
   }
   return spawnArray;
+}
+
+/**
+ * The needed configuration to convert an object of options into an array of CLI parameters.
+ */
+export interface CommandLineParamFixes<TKey extends string> {
+  /**
+   * A map of the option keys and what those flags are named in the cli
+   */
+  keyMap: Partial<Record<TKey, string>>;
+  /**
+   * These are keys that need to be passed as `--key false` instead of not including in the flags
+   */
+  explicitFalseKeys: readonly TKey[];
+}
+
+/**
+ * Converts an object of options like `{ noBuild: true }`into an array of CLI parameters like `["--no-build"]`
+ * Will run a conversion process to change every option to a string, and will map keys to different flags if needed.
+ */
+export function convertOptionsToParams<TKey extends string>(
+  options: Partial<Record<TKey, string | boolean | number | undefined | null>>,
+  fixes: CommandLineParamFixes<TKey>,
+): string[] {
+  const entries = Object.entries(options).map(([key, value]) => [
+    key in fixes.keyMap ? fixes.keyMap[key as TKey] : key,
+    (fixes.explicitFalseKeys as readonly string[]).includes(key) &&
+    value === false
+      ? 'false'
+      : value,
+  ]);
+  return getSpawnParameterArray(Object.fromEntries(entries));
 }

--- a/packages/utils/src/lib/utility-functions/parameters.ts
+++ b/packages/utils/src/lib/utility-functions/parameters.ts
@@ -29,9 +29,10 @@ export function getSpawnParameterArray(
 ): string[] {
   const spawnArray: string[] = [];
   for (const [key, value] of Object.entries(parameters)) {
-    // true booleans are flags, explicit false booleans follow regular key-value pattern
-    if (typeof value === 'boolean' && value) {
-      spawnArray.push(`--${key}`);
+    if (typeof value === 'boolean') {
+      if (value) {
+        spawnArray.push(`--${key}`);
+      }
     } else if (value !== undefined && value !== null) {
       spawnArray.push(`--${key}`, value.toString());
     }


### PR DESCRIPTION
fixes #812
Made the keys that need the word "false" an explicit thing to handle, since it seems to be the exception.

I am not sure if there are other flags that need to be this explicit false thing. I could only handle the ones that have test cases written.

I have also refactored the handling of converting options to params, since it is repeating the same calls over and over.