### PR TITLE
Fix warning "Project 'xxx' contains extension with invalid name (type)."

### DIFF
--- a/packages/core/src/graph/create-nodes.ts
+++ b/packages/core/src/graph/create-nodes.ts
@@ -141,7 +141,7 @@ export const createNodes: CreateNodesCompat<NxDotnetConfigV2> = [
         [name]: {
           name,
           root,
-          type: 'lib',
+          projectType: 'library',
           targets: registerProjectTargets(file, options),
           tags: options.tags,
         },


### PR DESCRIPTION
Fixes the Nx warning `Project 'xxx.xxx' contains extension with invalid name (type).`