### PR TITLE
fix(dotnet): serve should work with dotnet 8

### DIFF
--- a/packages/core/src/executors/serve/executor.ts
+++ b/packages/core/src/executors/serve/executor.ts
@@ -39,7 +39,5 @@ const runDotnetRun = async (
 
   childProcess = dotnetClient.run(project, watch, commandLineOptions);
   await handleChildProcessPassthrough(childProcess);
-  await rimraf(projectDirectory + '/bin');
-  await rimraf(projectDirectory + '/obj');
   return { success: true };
 };

--- a/packages/dotnet/src/lib/core/dotnet.client.spec.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.spec.ts
@@ -92,8 +92,7 @@ describe('dotnet client', () => {
           "publish",
           ""my-project"",
           "--no-restore",
-          "--configuration",
-          "Release",
+          "--configuration=Release",
         ]
       `);
     });
@@ -267,8 +266,7 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
               "format",
               "analyzers",
               "my-project",
-              "--severity",
-              "warn",
+              "--severity=warn",
             ],
           ],
         ]
@@ -359,8 +357,7 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
               "format",
               "style",
               "my-project",
-              "--severity",
-              "warn",
+              "--severity=warn",
             ],
           ],
           [
@@ -449,8 +446,7 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
             [
               "format",
               "my-project",
-              "--fix-whitespace",
-              "false",
+              "--fix-whitespace=false",
             ],
           ],
         ]
@@ -472,8 +468,7 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
             [
               "format",
               "my-project",
-              "--fix-style",
-              "false",
+              "--fix-style=false",
             ],
           ],
         ]
@@ -495,8 +490,7 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
             [
               "format",
               "my-project",
-              "--fix-analyzers",
-              "false",
+              "--fix-analyzers=false",
             ],
           ],
         ]
@@ -523,8 +517,7 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
           "my-project",
           "--no-restore",
           "--blame-hang",
-          "--blame-hang-dump",
-          "dump.file",
+          "--blame-hang-dump=dump.file",
         ]
       `);
     });
@@ -547,8 +540,7 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
           "build",
           "my-project",
           "--no-restore",
-          "--configuration",
-          "Release",
+          "--configuration=Release",
         ]
       `);
     });
@@ -572,8 +564,7 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
           "package",
           "other-package",
           "--no-restore",
-          "--version",
-          "1.2.3",
+          "--version=1.2.3",
         ]
       `);
     });
@@ -596,8 +587,7 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
           "new",
           "my-template",
           "--dry-run",
-          "--name",
-          "my-project",
+          "--name=my-project",
         ]
       `);
     });
@@ -621,8 +611,7 @@ ASP.NET Core gRPC Service                         grpc            [C#]          
           "--project",
           "my-project",
           "--no-restore",
-          "--configuration",
-          "Release",
+          "--property:Configuration=Release",
         ]
       `);
     });

--- a/packages/dotnet/src/lib/models/dotnet-run/dotnet-run-flags.ts
+++ b/packages/dotnet/src/lib/models/dotnet-run/dotnet-run-flags.ts
@@ -20,6 +20,7 @@ export const runCommandLineParamFixes: CommandLineParamFixes<dotnetRunFlags> = {
     noRestore: 'no-restore',
     versionSuffix: 'version-suffix',
     noIncremental: 'no-incremental',
+    configuration: 'property:Configuration',
   },
   explicitFalseKeys: [],
 };

--- a/packages/utils/src/lib/utility-functions/parameters.spec.ts
+++ b/packages/utils/src/lib/utility-functions/parameters.spec.ts
@@ -15,11 +15,9 @@ describe('convertOptionsToParams', () => {
     });
     expect(result).toMatchInlineSnapshot(`
       [
-        "--fixWhitespace",
-        "false",
+        "--fixWhitespace=false",
         "--fixStyle",
-        "--fixAnalyzers",
-        "false",
+        "--fixAnalyzers=false",
         "--noDependencies",
       ]
     `);

--- a/packages/utils/src/lib/utility-functions/parameters.ts
+++ b/packages/utils/src/lib/utility-functions/parameters.ts
@@ -34,7 +34,7 @@ export function getSpawnParameterArray(
         spawnArray.push(`--${key}`);
       }
     } else if (value !== undefined && value !== null) {
-      spawnArray.push(`--${key}`, value.toString());
+      spawnArray.push(`--${key}=${value.toString()}`);
     }
   }
   return spawnArray;


### PR DESCRIPTION
In .NET 8 some changes made passing `--configuration Debug` invalid. This PR swaps that to look more like `--property:Configuration=Debug` wihch should work in both .NET 8 and lower

Fixes #865