### PR TITLE
fix(repo): published packages should include resolved versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "prettier": "^3.0.3",
     "prettier-2": "npm:prettier@^2",
     "react-refresh": "^0.10.0",
-    "run-p": "*",
     "strip-ansi": "^6.0.1",
     "style-loader": "^3.3.0",
     "stylus": "0.59.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,8 +8,8 @@
     "postinstall": "node ./src/tasks/post-install"
   },
   "dependencies": {
-    "@nx-dotnet/dotnet": "*",
-    "@nx-dotnet/utils": "*",
+    "@nx-dotnet/dotnet": "file:../dotnet",
+    "@nx-dotnet/utils": "file:../utils",
     "@nx/devkit": "19.5.3",
     "fast-glob": "3.2.12",
     "inquirer": "^8.2.0",

--- a/packages/dotnet/package.json
+++ b/packages/dotnet/package.json
@@ -3,7 +3,7 @@
   "private": false,
   "main": "src/index.js",
   "dependencies": {
-    "@nx-dotnet/utils": "*",
+    "@nx-dotnet/utils": "file:../utils",
     "semver": "7.5.4",
     "tslib": "^2.5.0"
   },


### PR DESCRIPTION
Nx release doesn't replace version specified by `*`, whereas our custom script used to do so

Fixes https://github.com/nx-dotnet/nx-dotnet/issues/876