### PR TITLE
chore: relax version peerdep for openapi cli

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "nx": ">=18.0.0 <20.0.0",
     "@nx/js": ">=16.0.0-beta.1",
-    "@openapitools/openapi-generator-cli": "2.13.4",
+    "@openapitools/openapi-generator-cli": "^2.13.4",
     "eslint": ">8.0.0",
     "prettier": ">=2.0.0"
   },


### PR DESCRIPTION
Fixes https://github.com/nx-dotnet/nx-dotnet/issues/888