### PR TITLE
docs: fix paths on index page

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -75,72 +75,72 @@ If your workspace does not currently contain eslint, do not worry! You do not ha
 
 ## Generators
 
-### [library](./generators/library)
+### [library](/core/generators/library)
 
 Generate a new C# project as an Nx library
 
-### [application](./generators/application)
+### [application](/core/generators/application)
 
 Generate a new C# project as an Nx application
 
-### [project-reference](./generators/project-reference)
+### [project-reference](/core/generators/project-reference)
 
 Add a reference from one project to another
 
-### [sync](./generators/sync)
+### [sync](/core/generators/sync)
 
 Synchronizes NuGet references for the workspace
 
-### [nuget-reference](./generators/nuget-reference)
+### [nuget-reference](/core/generators/nuget-reference)
 
 Add a NuGet reference to a project
 
-### [restore](./generators/restore)
+### [restore](/core/generators/restore)
 
 Restores NuGet packages and .NET tools used by the workspace
 
-### [test](./generators/test)
+### [test](/core/generators/test)
 
 Generate a .NET test project for an existing application or library
 
-### [add-swagger-target](./generators/add-swagger-target)
+### [add-swagger-target](/core/generators/add-swagger-target)
 
 Add a swagger target to a webapi based project to extract swagger.json into a newly generated library project
 
-### [swagger-typescript](./generators/swagger-typescript)
+### [swagger-typescript](/core/generators/swagger-typescript)
 
 Generate a typescript library project based on an openapi/swagger specification file
 
-### [move](./generators/move)
+### [move](/core/generators/move)
 
 Moves a .NET project (including updating references)
 
 ## Executors
 
-### [build](./executors/build)
+### [build](/core/executors/build)
 
 Invokes `dotnet build` to build a project with .NET Core CLI
 
-### [serve](./executors/serve)
+### [serve](/core/executors/serve)
 
 Invokes `dotnet watch` in combination with `dotnet build` to run a dev-server
 
-### [test](./executors/test)
+### [test](/core/executors/test)
 
 Invokes `dotnet test` to execute unit tests via .NET Core CLI
 
-### [publish](./executors/publish)
+### [publish](/core/executors/publish)
 
 Invokes `dotnet publish`
 
-### [format](./executors/format)
+### [format](/core/executors/format)
 
 Formats and lints a project using the dotnet-format tool
 
-### [update-swagger](./executors/update-swagger)
+### [update-swagger](/core/executors/update-swagger)
 
 Generates a swagger document for an API project
 
-### [openapi-codegen](./executors/openapi-codegen)
+### [openapi-codegen](/core/executors/openapi-codegen)
 
 Invokes `nx g @nx-dotnet/core:swagger-typescript` with the proper parameters to update a codegen based library


### PR DESCRIPTION
These paths were missing the core prefix. Not sure if this was the best way to do it, but doing `(generators/library)` didn't work, nor did `(/generators/library)`. They just went around the root. 