### PR TITLE
Pass `host` to `isNxCrystalEnabled` function in `test` target generator

### DIFF
--- a/packages/core/src/generators/test/generator.ts
+++ b/packages/core/src/generators/test/generator.ts
@@ -50,7 +50,7 @@ export default async function (
       schema.suffix,
     );
 
-  if (!isNxCrystalEnabled()) {
+  if (!isNxCrystalEnabled(host)) {
     addProjectConfiguration(host, testProjectName, {
       root: testRoot,
       projectType: 'library',


### PR DESCRIPTION
### Description
This PR fixes the issue described in #939. 

### Details
It touches the `test` generator and uses `host` argument that is now being passed to `isNxCrystalEnabled` function for correct target inference usage.