### PR TITLE
fix(core): Delay throw  of error if .net cli not present until it is actually needed.

### DIFF
--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -351,6 +351,9 @@ export class DotNetClient {
   }
 
   public logAndExecute(params: string[]): void {
+    if(this.cliCommand.available === false) {
+      throw new Error('dotnet CLI is not available. Please ensure dotnet is installed and available in your PATH.');
+    }
     params = params.map((param) =>
       param.replace(/\$(\w+)/, (_, varName) => process.env[varName] ?? ''),
     );
@@ -369,6 +372,9 @@ export class DotNetClient {
   }
 
   private spawnAndGetOutput(params: string[]): string {
+    if(this.cliCommand.available === false) {
+      throw new Error('dotnet CLI is not available. Please ensure dotnet is installed and available in your PATH.');
+    }
     params = params.map((param) =>
       param.replace(/\$(\w+)/, (_, varName) => process.env[varName] ?? ''),
     );
@@ -387,6 +393,9 @@ export class DotNetClient {
   }
 
   async spawnAsyncAndGetOutput(params: string[]): Promise<string> {
+    if(this.cliCommand.available === false) {
+      throw new Error('dotnet CLI is not available. Please ensure dotnet is installed and available in your PATH.');
+    }
     params = params.map((param) =>
       param.replace(/\$(\w+)/, (_, varName) => process.env[varName] ?? ''),
     );
@@ -413,6 +422,9 @@ export class DotNetClient {
   }
 
   private logAndSpawn(params: string[]): ChildProcess {
+    if(this.cliCommand.available === false) {
+      throw new Error('dotnet CLI is not available. Please ensure dotnet is installed and available in your PATH.');
+    }
     console.log(
       `Executing Command: ${this.cliCommand.command} "${params.join('" "')}"`,
     );

--- a/packages/dotnet/src/lib/core/dotnet.client.ts
+++ b/packages/dotnet/src/lib/core/dotnet.client.ts
@@ -343,6 +343,9 @@ export class DotNetClient {
   }
 
   getSdkVersion(): string {
+    if(this.cliCommand.available === false) {
+      throw new Error('dotnet CLI is not available. Please ensure dotnet is installed and available in your PATH.');
+    }
     return this.cliCommand.info.version.toString();
   }
 

--- a/packages/dotnet/src/lib/core/dotnet.factory.ts
+++ b/packages/dotnet/src/lib/core/dotnet.factory.ts
@@ -20,6 +20,7 @@ export function dotnetFactory(): LoadedCLI {
       .toString('utf-8')
       .trim();
     return {
+      available: true,
       command: 'dotnet',
       info: {
         global: true,
@@ -30,19 +31,26 @@ export function dotnetFactory(): LoadedCLI {
     console.error(
       'dotnet not installed. Local support not yet added https://github.com/AgentEnder/nx-dotnet/issues/3',
     );
+    return {
+      available: false,
+    }
   }
 }
 
 export function mockDotnetFactory(version?: string): LoadedCLI {
   return {
+    available: true,
     command: 'echo',
     info: { global: true, version: version ?? '6.0.100' },
   };
 }
 
 export type LoadedCLI = {
+  available: true;
   command: string;
   info: { global: boolean; version: string | number };
+} | {
+  available: false;
 };
 
 export type DotnetFactory = () => LoadedCLI;

--- a/packages/dotnet/src/lib/core/dotnet.factory.ts
+++ b/packages/dotnet/src/lib/core/dotnet.factory.ts
@@ -27,7 +27,7 @@ export function dotnetFactory(): LoadedCLI {
       },
     };
   } catch (e) {
-    throw new Error(
+    console.error(
       'dotnet not installed. Local support not yet added https://github.com/AgentEnder/nx-dotnet/issues/3',
     );
   }


### PR DESCRIPTION
## Problem

FIx #952 

The nx-dotnet plugin is sometimes too aggressive when checking whether .NET is installed in the current environment. It performs this check even when the executed task has nothing to do with a .NET project.

This behavior is especially problematic in serverless environments like Vercel, where installing missing dependencies is not possible.

To make matters worse, the ignorePaths option does not work as expected. As a result, the .NET check is triggered for any Nx task—regardless of whether it involves a .NET project or not.

⸻

## Root Cause

The root cause appears to be related to the create-dependencies task, which performs the .NET check as part of every Nx invocation. I may be mistaken, and would appreciate any guidance or confirmation regarding this assumption.

⸻

## Solution

Instead of throwing an error when .NET is not present, the proposed change logs the error to the console and returns an object indicating that the cli is not present in order to continue execution. If .NET is actually required, one of the functions that do use the cli will notice that the return type of the clie factory is false and throw.

⸻

## Changes
	•	packages/dotnet/src/lib/core/dotnet.factory.ts:
Logs an error to the console instead of throwing an exception when .NET is not found.
Modifies  `LoadedCLI` type to be a discriminated union that can indicate if the CLI is present or not

•	packages/dotnet/src/lib/core/dotnet.client.ts:
Checks if `LoadedCLI` indicates if the CLI is available. If not, it throws.

⸻

## Testing

✅ Ran tasks in an environment without .NET and confirmed that the error is logged, not thrown.

⸻

## Impact
	•	Allows monorepos with mixed project types (e.g., not all using .NET) to run Nx tasks in serverless environments like Vercel.
	•	Avoids unnecessary failures when tasks are unrelated to .NET.
	•	No breaking changes.

